### PR TITLE
Import ts modules Dynamically

### DIFF
--- a/apitests/.gitignore
+++ b/apitests/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Editor directories and files
+.vscode

--- a/apitests/package-lock.json
+++ b/apitests/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@tensorflow/tfjs": "^4.4.0",
+        "@tensorflow/tfjs-node": "^4.4.0",
         "@tensorflow/tfjs-node-gpu": "^4.4.0"
       },
       "devDependencies": {
@@ -644,6 +645,25 @@
         "@tensorflow/tfjs-core": "4.4.0"
       }
     },
+    "node_modules/@tensorflow/tfjs-node": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.4.0.tgz",
+      "integrity": "sha512-+JSAddsupjSQUDZeb7QGOFkL3Tty3kjPHx8ethiYFzwTZJHCMvM7wZJd0Fqnjxym6A0KpsmB7SPZgwRRXVIlPA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "1.0.9",
+        "@tensorflow/tfjs": "4.4.0",
+        "adm-zip": "^0.5.2",
+        "google-protobuf": "^3.9.2",
+        "https-proxy-agent": "^2.2.1",
+        "progress": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "tar": "^4.4.6"
+      },
+      "engines": {
+        "node": ">=8.11.0"
+      }
+    },
     "node_modules/@tensorflow/tfjs-node-gpu": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node-gpu/-/tfjs-node-gpu-4.4.0.tgz",
@@ -664,6 +684,17 @@
       }
     },
     "node_modules/@tensorflow/tfjs-node-gpu/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-node/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
@@ -4248,6 +4279,31 @@
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.4.0.tgz",
       "integrity": "sha512-OGC7shfiD9Gc698hINHK4y9slOJvu5m54tVNm4xf+WSNrw/avvgpar6yyoL5bakYIZNQvFNK75Yr8VRPR7oPeQ==",
       "requires": {}
+    },
+    "@tensorflow/tfjs-node": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.4.0.tgz",
+      "integrity": "sha512-+JSAddsupjSQUDZeb7QGOFkL3Tty3kjPHx8ethiYFzwTZJHCMvM7wZJd0Fqnjxym6A0KpsmB7SPZgwRRXVIlPA==",
+      "requires": {
+        "@mapbox/node-pre-gyp": "1.0.9",
+        "@tensorflow/tfjs": "4.4.0",
+        "adm-zip": "^0.5.2",
+        "google-protobuf": "^3.9.2",
+        "https-proxy-agent": "^2.2.1",
+        "progress": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "tar": "^4.4.6"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "@tensorflow/tfjs-node-gpu": {
       "version": "4.4.0",

--- a/apitests/package.json
+++ b/apitests/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "^4.4.0",
+    "@tensorflow/tfjs-node": "^4.4.0",
     "@tensorflow/tfjs-node-gpu": "^4.4.0"
   }
 }

--- a/apitests/src/creation/buffer.spec.ts
+++ b/apitests/src/creation/buffer.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import * as tf from "@tensorflow/tfjs";
+
+/* tf.TensorBuffer: A mutable object, similar to tf.Tensor, that allows users to set values at locations before converting to an immutable tf.Tensor. */
+describe("tf.buffer(): ", () => {
+  it("  -- default options", () => {
+    const buffer: tf.TensorBuffer<tf.Rank.R2> = tf.buffer([2, 2]);
+    expect(buffer.shape).to.eql([2, 2]);
+    expect(buffer.size).to.eql(4);
+    buffer.set(4, 0, 0);
+    buffer.set(6, 0, 1);
+    buffer.set(8, 1, 0);
+    buffer.set(10, 1, 1);
+    const expected = [
+      [4, 6],
+      [8, 10],
+    ];
+    expect(buffer.toTensor().arraySync()).to.eql(expected);
+  });
+  it("  -- dtype", () => {
+    const buffer: tf.TensorBuffer<tf.Rank.R2, "int32"> = tf.buffer(
+      [2, 2],
+      "int32"
+    );
+    expect(buffer.dtype).to.equal("int32");
+  });
+  it("  -- values", () => {
+    const buffer: tf.TensorBuffer<tf.Rank.R2, keyof tf.DataTypeMap> = tf.buffer(
+      [2, 2],
+      undefined,
+      Int32Array.from([1, 2, 3, 4])
+    );
+    const expected = [
+      [1, 2],
+      [3, 4],
+    ];
+    expect(buffer.toTensor().arraySync()).to.eql(expected);
+  });
+});

--- a/apitests/src/creation/clone.spec.ts
+++ b/apitests/src/creation/clone.spec.ts
@@ -1,0 +1,14 @@
+import { expect } from "chai";
+import * as tf from "@tensorflow/tfjs";
+
+describe("tf.clone(): ", () => {
+  it("  -- clones a tensor", () => {
+    const arr = [
+      [1, 2, 3],
+      [4, 5, 6],
+    ];
+    const t: tf.Tensor = tf.tensor(arr);
+    const clone: tf.Tensor = t.clone();
+    expect(clone.shape).to.eql([2, 3]);
+  });
+});

--- a/apitests/src/creation/complex.spec.ts
+++ b/apitests/src/creation/complex.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+import * as tf from "@tensorflow/tfjs";
+
+describe("tf.complex(): ", () => {
+  it("  -- converts 2 real numbers to a complex number", () => {
+    const real: tf.Tensor2D = tf.tensor2d([
+      [0, 1],
+      [2, 3],
+    ]);
+    const imag: tf.Tensor2D = tf.tensor2d([
+      [0, 10],
+      [20, 30],
+    ]);
+    const complex: tf.Tensor2D = tf.complex(real, imag);
+    expect(complex.dtype).to.equal("complex64");
+    expect(complex.size).to.equal(4);
+  });
+});

--- a/apitests/src/creation/eye.spec.ts
+++ b/apitests/src/creation/eye.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
-import loadTf from "../load-tf";
-import type tfTypes from "@tensorflow/tfjs";
+import * as loader from "../load-tf";
+import type tfTypes from "@tensorflow/tfjs-core";
 
 describe("tf.eye(numRows, numColumns?, batchShape?, dtype?): ", async () => {
-  const tf = await loadTf();
+  const tf: loader.TFModule = await loader.load();
   it("  -- basic", () => {
     const t: tfTypes.Tensor2D = tf.eye(3);
     const expected = [

--- a/apitests/src/creation/eye.spec.ts
+++ b/apitests/src/creation/eye.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import loadTf from "../load-tf";
+import type tfTypes from "@tensorflow/tfjs";
+
+describe("tf.eye(numRows, numColumns?, batchShape?, dtype?): ", async () => {
+  const tf = await loadTf();
+  it("  -- basic", () => {
+    const t: tfTypes.Tensor2D = tf.eye(3);
+    const expected = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    expect(t.arraySync()).to.eql(expected);
+  });
+});

--- a/apitests/src/load-tf.ts
+++ b/apitests/src/load-tf.ts
@@ -1,7 +1,23 @@
-export default async function () {
-  if (process.env.OS === "linux") {
-    return await import("@tensorflow/tfjs-node-gpu");
-  } else {
-    return await import("@tensorflow/tfjs");
+/* To Import: "import * from load-tf" */
+
+/* -- Types -- */
+// private
+type GPUModule = typeof import("@tensorflow/tfjs-node-gpu");
+type JSModule = typeof import("@tensorflow/tfjs");
+// public
+export type TFModule = GPUModule | JSModule;
+
+/* -- Functions: -- */
+
+// load(): Loads tensorflow library dynamically based on OS
+export async function load(): Promise<TFModule> {
+  try {
+    if (process.env.OS === "linux") {
+      return await import("@tensorflow/tfjs-node-gpu");
+    } else {
+      return await import("@tensorflow/tfjs");
+    }
+  } catch (err) {
+    throw new Error("Failed to load TensorFlow library");
   }
 }

--- a/apitests/src/load-tf.ts
+++ b/apitests/src/load-tf.ts
@@ -1,23 +1,58 @@
-/* To Import: "import * from load-tf" */
+import Os from "os";
+import * as dotenv from "dotenv";
+dotenv.config();
+/* 
+Loads a tensorflow module based on environment variable TF_MODULE
+EXPORTS: load() function, TFModule type
+( To Import this module elsewhere: "import * from load-tf" ) 
+*/
 
 /* -- Types -- */
 // private
 type GPUModule = typeof import("@tensorflow/tfjs-node-gpu");
 type JSModule = typeof import("@tensorflow/tfjs");
+type NodeModule = typeof import("@tensorflow/tfjs-node");
 // public
-export type TFModule = GPUModule | JSModule;
+export type TFModule = GPUModule | JSModule | NodeModule;
+
+/* -- Constants -- */
+
+// posible values of TF_MODULE. TF_MODULE must match a tensorflowjs module name
+const MODULES = {
+  tfjs: "tfjs",
+  "tfjs-node-gpu": "tfjs-node-gpu",
+  "tfjs-node": "tfjs-node",
+};
+const DEFAULT_MODULE = MODULES.tfjs;
 
 /* -- Functions: -- */
 
-// load(): Loads tensorflow library dynamically based on OS
+/* load(): Loads tensorflow library dynamically based on OS */
 export async function load(): Promise<TFModule> {
   try {
-    if (process.env.OS === "linux") {
-      return await import("@tensorflow/tfjs-node-gpu");
+    let module = process.env.TF_MODULE;
+    if (module === MODULES["tfjs-node-gpu"]) {
+      if (!isLinux()) throw new Error("GPU not supported on this OS");
+    } else if (module === MODULES["tfjs-node"]) {
+      if (!isArm64()) throw new Error("Node not supported on this CPU");
     } else {
-      return await import("@tensorflow/tfjs");
+      module = DEFAULT_MODULE;
     }
+    //return: Promise<GPUModule | JSModule | NodeModule>
+    return await import(`@tensorflow/${module}`);
   } catch (err) {
+    // Error handling
+    let message = "Unknown Error";
+    if (err instanceof Error) message = err.message;
+    console.error(message);
     throw new Error("Failed to load TensorFlow library");
   }
+}
+
+function isLinux(): boolean {
+  return Os.platform() === "linux";
+}
+
+function isArm64(): boolean {
+  return process.arch === "arm64";
 }

--- a/apitests/src/load-tf.ts
+++ b/apitests/src/load-tf.ts
@@ -1,0 +1,7 @@
+export default async function () {
+  if (process.env.OS === "linux") {
+    return await import("@tensorflow/tfjs-node-gpu");
+  } else {
+    return await import("@tensorflow/tfjs");
+  }
+}


### PR DESCRIPTION
## New Module: *load-tf.js*
  - `async load()` loads a tensorflowjs module
  - based on $TF_MODULE value
  - checks for compatibility with machine architecture and os
  - if not $TF_MODULE undefined or not valid : defaults to DEFAULT_MODULE 
  - imports `dotenv` npm package

## Setup

### Either:

 **dotenv package**
  1. Create *.env* file in root directory ( *apitests/* )
  2. In *.env* : `TF_MODULE="tfjs"`
  3. make sure `dotenv` package is installed

*Or*

  **Terminal** 
   1. Set $TF_MODULE in terminal
   2. E.g. : `TF_MODULE='tfjs' npm test`

## Usage
  1. `import * as loader from "../load-tf";`
  2. `import type tfTypes from "@tensorflow/tfjs-core";`
  3. `const tf: loader.TFModule = await loader.load();`
  5. must be called within an async function, because top level await expressions are not allowed