### PR TITLE
Chai Plugin for Tensors

### DIFF
--- a/apitests/src/creation/buffer.spec.ts
+++ b/apitests/src/creation/buffer.spec.ts
@@ -1,11 +1,14 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 /* tf.TensorBuffer: A mutable object, similar to tf.Tensor, that allows users to set values at locations before converting to an immutable tf.Tensor. */
 describe("tf.buffer(): ", () => {
   it("  -- default options", () => {
     const buffer: tf.TensorBuffer<tf.Rank.R2> = tf.buffer([2, 2]);
-    expect(buffer.shape).to.eql([2, 2]);
+    expect(buffer).to.haveShape([2, 2]);
     expect(buffer.size).to.eql(4);
     buffer.set(4, 0, 0);
     buffer.set(6, 0, 1);
@@ -22,7 +25,7 @@ describe("tf.buffer(): ", () => {
       [2, 2],
       "int32"
     );
-    expect(buffer.dtype).to.equal("int32");
+    expect(buffer).to.haveDtype("int32");
   });
   it("  -- values", () => {
     const buffer: tf.TensorBuffer<tf.Rank.R2, keyof tf.DataTypeMap> = tf.buffer(

--- a/apitests/src/creation/clone.spec.ts
+++ b/apitests/src/creation/clone.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 describe("tf.clone(): ", () => {
@@ -9,6 +12,6 @@ describe("tf.clone(): ", () => {
     ];
     const t: tf.Tensor = tf.tensor(arr);
     const clone: tf.Tensor = t.clone();
-    expect(clone.shape).to.eql([2, 3]);
+    expect(clone).to.haveShape([2, 3]);
   });
 });

--- a/apitests/src/creation/complex.spec.ts
+++ b/apitests/src/creation/complex.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 describe("tf.complex(): ", () => {
@@ -12,7 +15,7 @@ describe("tf.complex(): ", () => {
       [20, 30],
     ]);
     const complex: tf.Tensor2D = tf.complex(real, imag);
-    expect(complex.dtype).to.equal("complex64");
+    expect(complex).to.haveDtype("complex64");
     expect(complex.size).to.equal(4);
   });
 });

--- a/apitests/src/creation/eye.spec.ts
+++ b/apitests/src/creation/eye.spec.ts
@@ -13,4 +13,33 @@ describe("tf.eye(numRows, numColumns?, batchShape?, dtype?): ", async () => {
     ];
     expect(t.arraySync()).to.eql(expected);
   });
+  it("  -- numColumns", () => {
+    const t: tfTypes.Tensor2D = tf.eye(3, 2);
+    const expected = [
+      [1, 0],
+      [0, 1],
+      [0, 0],
+    ];
+    expect(t.arraySync()).to.eql(expected);
+  });
+  it("  -- batchShape", () => {
+    const t: tfTypes.Tensor2D = tf.eye(3, undefined, [1, 1]);
+    const identityMatrix = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    const expected = [[identityMatrix]];
+    expect(t.arraySync()).to.eql(expected);
+  });
+  it("  -- dtypes", () => {
+    const t: tfTypes.Tensor2D = tf.eye(3, undefined, undefined, "int32");
+    const expected = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    expect(t.dtype).to.eql("int32");
+    expect(t.arraySync()).to.eql(expected);
+  });
 });

--- a/apitests/src/creation/eye.spec.ts
+++ b/apitests/src/creation/eye.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as loader from "../load-tf";
 import type tfTypes from "@tensorflow/tfjs-core";
 
@@ -39,7 +42,7 @@ describe("tf.eye(numRows, numColumns?, batchShape?, dtype?): ", async () => {
       [0, 1, 0],
       [0, 0, 1],
     ];
-    expect(t.dtype).to.eql("int32");
+    expect(t).to.haveDtype("int32");
     expect(t.arraySync()).to.eql(expected);
   });
 });

--- a/apitests/src/creation/fill.spec.ts
+++ b/apitests/src/creation/fill.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import * as loader from "../load-tf";
+import type tfTypes from "@tensorflow/tfjs-core";
+
+describe("tf.fill(shape, value, dtype?): ", async () => {
+  const tf: loader.TFModule = await loader.load();
+  it("  -- basic", () => {
+    const t: tfTypes.Tensor3D = tf.fill([3, 2, 3], 1);
+    const expected = [
+      [
+        [1, 1, 1],
+        [1, 1, 1],
+      ],
+      [
+        [1, 1, 1],
+        [1, 1, 1],
+      ],
+      [
+        [1, 1, 1],
+        [1, 1, 1],
+      ],
+    ];
+    expect(t.arraySync()).to.eql(expected);
+  });
+  it("  -- dtype", () => {
+    const t: tfTypes.Tensor2D = tf.fill([2, 1], 4, "int32");
+    const expected = [[4], [4]];
+    expect(t.dtype).to.eql("int32");
+    expect(t.arraySync()).to.eql(expected);
+  });
+});

--- a/apitests/src/creation/fill.spec.ts
+++ b/apitests/src/creation/fill.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as loader from "../load-tf";
 import type tfTypes from "@tensorflow/tfjs-core";
 
@@ -25,7 +28,7 @@ describe("tf.fill(shape, value, dtype?): ", async () => {
   it("  -- dtype", () => {
     const t: tfTypes.Tensor2D = tf.fill([2, 1], 4, "int32");
     const expected = [[4], [4]];
-    expect(t.dtype).to.eql("int32");
+    expect(t).to.haveDtype("int32");
     expect(t.arraySync()).to.eql(expected);
   });
 });

--- a/apitests/src/creation/scalar.spec.ts
+++ b/apitests/src/creation/scalar.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 // See: https://js.tensorflow.org/api/latest/#tensor
@@ -6,7 +9,7 @@ describe("tf.scalar(): ", () => {
   it("  -- default options", () => {
     const t: tf.Scalar = tf.scalar(2);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([]);
+    expect(t).to.haveShape([]);
     expect(t.arraySync()).to.eql(2);
   });
   it("  -- shapes", () => {

--- a/apitests/src/creation/scalar.spec.ts
+++ b/apitests/src/creation/scalar.spec.ts
@@ -14,7 +14,7 @@ describe("tf.scalar(): ", () => {
   });
   it("  -- shapes", () => {
     const t: tf.Scalar = tf.scalar(true, "bool");
-    expect(t.dtype).to.equal("bool");
+    expect(t).to.haveDtype("bool");
     expect(t.shape).to.eql([]);
     // Note: arraySync converts bools to numbers (0 or 1)
     expect(t.arraySync()).to.eql(1);

--- a/apitests/src/creation/tensor.spec.ts
+++ b/apitests/src/creation/tensor.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 // See: https://js.tensorflow.org/api/latest/#tensor
@@ -10,7 +13,7 @@ describe("tf.tensor(): ", () => {
   it("  -- shapes", () => {
     const t: tf.Tensor<tf.Rank.R2> = tf.tensor([2, 3, 4, 5], [2, 2]);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([2, 2]);
+    expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [2.0, 3.0],
       [4.0, 5.0],
@@ -26,7 +29,7 @@ describe("tf.tensor(): ", () => {
       "int32"
     );
     expect(t.dtype).to.equal("int32");
-    expect(t.shape).to.eql([2, 2]);
+    expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [2, 3],
       [4, 5],

--- a/apitests/src/creation/tensor.spec.ts
+++ b/apitests/src/creation/tensor.spec.ts
@@ -12,7 +12,7 @@ describe("tf.tensor(): ", () => {
   });
   it("  -- shapes", () => {
     const t: tf.Tensor<tf.Rank.R2> = tf.tensor([2, 3, 4, 5], [2, 2]);
-    expect(t.dtype).to.equal("float32");
+    expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [2.0, 3.0],
@@ -28,7 +28,7 @@ describe("tf.tensor(): ", () => {
       undefined,
       "int32"
     );
-    expect(t.dtype).to.equal("int32");
+    expect(t).to.haveDtype("int32");
     expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [2, 3],

--- a/apitests/src/creation/tensor1d-tensor6d.spec.ts
+++ b/apitests/src/creation/tensor1d-tensor6d.spec.ts
@@ -13,7 +13,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
   });
   it("  -- tf.tensor1d()", () => {
     const t: tf.Tensor1D = tf.tensor1d([1, 2, 3, 4]);
-    expect(t.dtype).to.equal("float32");
+    expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([4]);
     expect(t.arraySync()).to.eql([1, 2, 3, 4]);
   });
@@ -22,7 +22,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
       [1, 2],
       [3, 4],
     ]);
-    expect(t.dtype).to.equal("float32");
+    expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [1, 2],
@@ -42,7 +42,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
     ];
 
     const t: tf.Tensor3D = tf.tensor3d(array, undefined, "int32");
-    expect(t.dtype).to.equal("int32");
+    expect(t).to.haveDtype("int32");
     expect(t).to.haveShape([2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });
@@ -71,7 +71,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
     ];
 
     const t: tf.Tensor4D = tf.tensor4d(array, undefined, "int32");
-    expect(t.dtype).to.equal("int32");
+    expect(t).to.haveDtype("int32");
     expect(t).to.haveShape([2, 2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });
@@ -124,7 +124,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
     ];
 
     const t: tf.Tensor5D = tf.tensor5d(array);
-    expect(t.dtype).to.equal("float32");
+    expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([2, 2, 2, 2, 3]);
     expect(t.arraySync()).to.eql(array);
   });
@@ -225,7 +225,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
     ];
 
     const t: tf.Tensor = tf.tensor6d(array);
-    expect(t.dtype).to.equal("float32");
+    expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([2, 2, 2, 2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });

--- a/apitests/src/creation/tensor1d-tensor6d.spec.ts
+++ b/apitests/src/creation/tensor1d-tensor6d.spec.ts
@@ -15,7 +15,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
     const t: tf.Tensor1D = tf.tensor1d([1, 2, 3, 4]);
     expect(t).to.haveDtype("float32");
     expect(t).to.haveShape([4]);
-    expect(t.arraySync()).to.eql([1, 2, 3, 4]);
+    expect(t).to.lookLike([1, 2, 3, 4]);
   });
   it("  -- tf.tensor2d()", () => {
     const t: tf.Tensor2D = tf.tensor2d([

--- a/apitests/src/creation/tensor1d-tensor6d.spec.ts
+++ b/apitests/src/creation/tensor1d-tensor6d.spec.ts
@@ -1,4 +1,7 @@
-import { expect } from "chai";
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
 import * as tf from "@tensorflow/tfjs";
 
 // See: https://js.tensorflow.org/api/latest/#tensor
@@ -11,7 +14,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
   it("  -- tf.tensor1d()", () => {
     const t: tf.Tensor1D = tf.tensor1d([1, 2, 3, 4]);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([4]);
+    expect(t).to.haveShape([4]);
     expect(t.arraySync()).to.eql([1, 2, 3, 4]);
   });
   it("  -- tf.tensor2d()", () => {
@@ -20,7 +23,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
       [3, 4],
     ]);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([2, 2]);
+    expect(t).to.haveShape([2, 2]);
     expect(t.arraySync()).to.eql([
       [1, 2],
       [3, 4],
@@ -40,7 +43,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
 
     const t: tf.Tensor3D = tf.tensor3d(array, undefined, "int32");
     expect(t.dtype).to.equal("int32");
-    expect(t.shape).to.eql([2, 2, 2]);
+    expect(t).to.haveShape([2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });
   it("  -- tf.tensor4d()", () => {
@@ -69,7 +72,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
 
     const t: tf.Tensor4D = tf.tensor4d(array, undefined, "int32");
     expect(t.dtype).to.equal("int32");
-    expect(t.shape).to.eql([2, 2, 2, 2]);
+    expect(t).to.haveShape([2, 2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });
   it("  -- tf.tensor5d()", () => {
@@ -122,7 +125,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
 
     const t: tf.Tensor5D = tf.tensor5d(array);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([2, 2, 2, 2, 3]);
+    expect(t).to.haveShape([2, 2, 2, 2, 3]);
     expect(t.arraySync()).to.eql(array);
   });
   it("  -- tf.tensor6d()", () => {
@@ -223,7 +226,7 @@ describe("tf.tensorNd() : n∈{1, 2, 3, 4, 5, 6}", () => {
 
     const t: tf.Tensor = tf.tensor6d(array);
     expect(t.dtype).to.equal("float32");
-    expect(t.shape).to.eql([2, 2, 2, 2, 2, 2]);
+    expect(t).to.haveShape([2, 2, 2, 2, 2, 2]);
     expect(t.arraySync()).to.eql(array);
   });
 });

--- a/apitests/src/plugins/tensor-chai/index.d.ts
+++ b/apitests/src/plugins/tensor-chai/index.d.ts
@@ -1,9 +1,19 @@
 export {};
 declare global {
+  // type nArray = number[] | number[][] | number[][][] | number[][][][] | number[][][][][] | number[][][][][][]};
   namespace Chai {
     interface Assertion {
       haveShape(shape: Array<number>): void;
       haveDtype(dtype: keyof tf.DataTypeMap): void;
+      lookLike(
+        arr:
+          | number[]
+          | number[][]
+          | number[][][]
+          | number[][][][]
+          | number[][][][][]
+          | number[][][][][][]
+      ): void;
     }
   }
 }

--- a/apitests/src/plugins/tensor-chai/index.d.ts
+++ b/apitests/src/plugins/tensor-chai/index.d.ts
@@ -1,0 +1,8 @@
+export {};
+declare global {
+  namespace Chai {
+    interface Assertion {
+      haveShape(shape: Array<number>): void;
+    }
+  }
+}

--- a/apitests/src/plugins/tensor-chai/index.d.ts
+++ b/apitests/src/plugins/tensor-chai/index.d.ts
@@ -3,6 +3,7 @@ declare global {
   namespace Chai {
     interface Assertion {
       haveShape(shape: Array<number>): void;
+      haveDtype(dtype: keyof tf.DataTypeMap): void;
     }
   }
 }

--- a/apitests/src/plugins/tensor-chai/index.ts
+++ b/apitests/src/plugins/tensor-chai/index.ts
@@ -6,7 +6,7 @@ export const tensorChaiPlugin: Chai.ChaiPlugin = function (
 ) {
   const Assertion = chai.Assertion;
 
-  // your helpers here
+  // new chai assertions : " expect(tensor).to.haveShape "
   Assertion.addMethod("haveShape", function haveShape(arr) {
     const obj: tf.Tensor = utils.flag(this, "object");
     new Assertion(obj.shape).to.eql(arr);
@@ -19,6 +19,11 @@ export const tensorChaiPlugin: Chai.ChaiPlugin = function (
       new Assertion(obj.dtype).to.eql(dtype);
     }
   );
+
+  Assertion.addMethod("lookLike", function lookLike(arr) {
+    const obj: tf.Tensor = utils.flag(this, "object");
+    new Assertion(obj.arraySync()).to.eql(arr);
+  });
 };
 
 // export default tensorChai;

--- a/apitests/src/plugins/tensor-chai/index.ts
+++ b/apitests/src/plugins/tensor-chai/index.ts
@@ -1,0 +1,16 @@
+import tf from "@tensorflow/tfjs-core";
+
+export const tensorChaiPlugin: Chai.ChaiPlugin = function (
+  chai: Chai.ChaiStatic,
+  utils: Chai.ChaiUtils
+) {
+  const Assertion = chai.Assertion;
+
+  // your helpers here
+  Assertion.addMethod("haveShape", function haveShape(arr) {
+    const obj: tf.Tensor = utils.flag(this, "object");
+    new Assertion(obj.shape).to.eql(arr);
+  });
+};
+
+// export default tensorChai;

--- a/apitests/src/plugins/tensor-chai/index.ts
+++ b/apitests/src/plugins/tensor-chai/index.ts
@@ -11,6 +11,14 @@ export const tensorChaiPlugin: Chai.ChaiPlugin = function (
     const obj: tf.Tensor = utils.flag(this, "object");
     new Assertion(obj.shape).to.eql(arr);
   });
+
+  Assertion.addMethod(
+    "haveDtype",
+    function haveDtype(dtype: keyof tf.DataTypeMap) {
+      const obj: tf.Tensor = utils.flag(this, "object");
+      new Assertion(obj.dtype).to.eql(dtype);
+    }
+  );
 };
 
 // export default tensorChai;

--- a/apitests/tsconfig.json
+++ b/apitests/tsconfig.json
@@ -26,12 +26,12 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    // "rootDir": "src",                                    /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "typeRoots": ["./node_modules/@types","./src/plugins"],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */


### PR DESCRIPTION
## New Methods:
### expect(x).to.haveShape(arr)
- Equivalent to:` expect(tensor.shape).to.eql(arr);`

### expect(x).to.haveDType(str)
- Equivalent to:` expect(tensor.dtype).to.eql(str);`

### expect(x).to.lookLike(arr)
- Equivalent to:` expect(tensor.arraySync()).to.eql(arr);`

## To Use:
In any *spec.ts* file:
```
import { tensorChaiPlugin } from "../plugins/tensor-chai";
chai.use(tensorChaiPlugin);
```

## New submodule : src/plugins/tensor-chai

### *index.ts*
- Exports the chai plugin as a function
- Inside the plugin are `addMethod()` functions, which expand chai assertions

### *index.d.ts*
- Contains the type signatures for the new chai methods
- expands `Chai.Assertion` type
- In `global`, so the ts transpiler can find them

## Config

### *tsconfig*
- Uncomment/Add: `"typeRoots": ["./node_modules/@types","./src/plugins"],`
- This tells the transpiler to look for types within the plugins directory, so it can find the *.d.ts* file

## Update test files to use new chai assertions

### *src/creations/*
- *buffer.ts*
- *clone.ts*
- *complex.ts*
- *eye.ts*
- *fill.ts*
- *scalar.ts*
- *tensor.ts*
- *tendor1d-6d.ts*