### PR TITLE
Complete Tests: all Tensors/classes and Tensors/transformations

### DIFF
--- a/apitests/package-lock.json
+++ b/apitests/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.4",
+        "@types/chai-as-promised": "^7.1.5",
         "@types/chai-spies": "^1.0.3",
         "@types/expect": "^24.3.0",
         "@types/mocha": "^10.0.1",
@@ -23,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "chai": "^4.3.7",
+        "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "dotenv": "^16.0.3",
         "eslint": "^8.39.0",
@@ -721,6 +723,15 @@
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/chai-spies": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/chai-spies/-/chai-spies-1.0.3.tgz",
@@ -1296,6 +1307,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chai-spies": {
@@ -4359,6 +4382,15 @@
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/chai-spies": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/chai-spies/-/chai-spies-1.0.3.tgz",
@@ -4781,6 +4813,15 @@
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chai-spies": {

--- a/apitests/package.json
+++ b/apitests/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/chai": "^4.3.4",
+    "@types/chai-as-promised": "^7.1.5",
     "@types/chai-spies": "^1.0.3",
     "@types/expect": "^24.3.0",
     "@types/mocha": "^10.0.1",
@@ -28,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "chai": "^4.3.7",
+    "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "dotenv": "^16.0.3",
     "eslint": "^8.39.0",

--- a/apitests/src/plugins/tensor-chai/index.d.ts
+++ b/apitests/src/plugins/tensor-chai/index.d.ts
@@ -1,4 +1,4 @@
-import { BasicType } from "../../utils";
+import { BasicType, TFArray, BoolArray } from "../../utils";
 export {};
 declare global {
   // type nArray = number[] | number[][] | number[][][] | number[][][][] | number[][][][][] | number[][][][][][]};
@@ -7,15 +7,7 @@ declare global {
       haveShape(shape: Array<number>): void;
       haveSize(size: number): void;
       haveDtype(dtype: keyof tf.DataTypeMap): void;
-      lookLike(
-        arr:
-          | number[]
-          | number[][]
-          | number[][][]
-          | number[][][][]
-          | number[][][][][]
-          | number[][][][][][]
-      ): void;
+      lookLike(arr: TFArray | BoolArray): void;
       filledWith(val: BasicType): void;
       allOnes: Assertion;
       allZeros: Assertion;

--- a/apitests/src/plugins/tensor-chai/index.ts
+++ b/apitests/src/plugins/tensor-chai/index.ts
@@ -2,7 +2,6 @@ import tf from "@tensorflow/tfjs-core";
 // Utils
 import { TensorUtils } from "../../utils";
 import { BasicType } from "../../utils";
-import tensorUtils from "../../utils/tensor-utils";
 
 export const tensorChaiPlugin: Chai.ChaiPlugin = function (
   chai: Chai.ChaiStatic,
@@ -31,7 +30,11 @@ export const tensorChaiPlugin: Chai.ChaiPlugin = function (
 
   Assertion.addMethod("lookLike", function lookLike(arr) {
     const obj: tf.Tensor = utils.flag(this, "object");
-    new Assertion(obj.arraySync()).to.eql(arr);
+    if (obj.dtype === "bool") {
+      new Assertion(TensorUtils.asBoolArray(obj)).to.eql(arr);
+    } else {
+      new Assertion(obj.arraySync()).to.eql(arr);
+    }
   });
 
   Assertion.addMethod("filledWith", function filledWith(val: BasicType) {
@@ -56,7 +59,7 @@ export const tensorChaiPlugin: Chai.ChaiPlugin = function (
     "allValuesInRange",
     function allValuesInRange(start: number, end: number) {
       const obj: tf.Tensor = utils.flag(this, "object");
-      tensorUtils.forEachTensorValue(obj, (val) => {
+      TensorUtils.forEachTensorValue(obj, (val) => {
         new Assertion(val).to.be.within(start, end);
       });
     }

--- a/apitests/src/tensors/classes/Tensor.ts
+++ b/apitests/src/tensors/classes/Tensor.ts
@@ -8,9 +8,10 @@ import * as loader from "../../load-tf";
 // utils
 import { areEqual } from "../../utils/tensor-utils";
 
+/* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
 
-// Types
+/* TYPES: */
 type TypedArray = Float32Array | Int32Array | Uint8Array | Uint16Array;
 
 /* -- tf.Tensor class methods-- */

--- a/apitests/src/tensors/classes/Tensor.ts
+++ b/apitests/src/tensors/classes/Tensor.ts
@@ -14,8 +14,11 @@ let tf: loader.TFModule;
 /* TYPES: */
 type TypedArray = Float32Array | Int32Array | Uint8Array | Uint16Array;
 
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
 /* -- tf.Tensor class methods-- */
 export function run() {
+  /* HOOKS: */
   before((done) => {
     loader.load().then((result: loader.TFModule) => {
       tf = result;
@@ -23,6 +26,8 @@ export function run() {
       done();
     });
   });
+
+  /* TESTS: */
   it("  -- Tensor.buffer()", async () => {
     // Returns a promise of tf.TensorBuffer that holds the underlying data.
     const t: tfTypes.Tensor<tfTypes.Rank.R1> = tf.tensor([2, 3]);

--- a/apitests/src/tensors/classes/TensorBuffer.ts
+++ b/apitests/src/tensors/classes/TensorBuffer.ts
@@ -1,0 +1,56 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+let tf: loader.TFModule;
+
+/* -- tf.TensorBuffer class methods-- */
+export function run() {
+  // **CONSTANTS:**
+  const SHAPE: [number, number] = [2, 2];
+
+  // **HOOKS:**
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+  // - to initialize before each test:
+  let buffer: tfTypes.TensorBuffer<tfTypes.Rank.R2>;
+  beforeEach(() => {
+    buffer = tf.buffer(SHAPE);
+  });
+
+  // **TESTS:**
+  it("  -- TensorBuffer.set()", () => {
+    buffer.set(4, 0, 1);
+    const t: tfTypes.Tensor<tfTypes.Rank.R2> = buffer.toTensor();
+    const expected = [
+      [0, 4],
+      [0, 0],
+    ];
+    expect(t.arraySync()).to.eql(expected);
+  });
+  it("  -- TensorBuffer.set() : indices out of range", () => {
+    // does not throw an error, but does not set the value either
+    buffer.set(4, 0, 6);
+    const t: tfTypes.Tensor<tfTypes.Rank.R2> = buffer.toTensor();
+    const expected = [
+      [0, 0],
+      [0, 0],
+    ];
+    expect(t.arraySync()).to.eql(expected);
+  });
+  it("  -- TensorBuffer.set() : location dimension not represented by shape of buffer", () => {
+    const NUM_COORDS = 3;
+    const RANK = buffer.rank;
+    expect(() => buffer.set(4, 0, 0, 1)).to.throw(
+      `The number of provided coordinates (${NUM_COORDS}) must match the rank (${RANK})`
+    );
+  });
+}

--- a/apitests/src/tensors/classes/TensorBuffer.ts
+++ b/apitests/src/tensors/classes/TensorBuffer.ts
@@ -8,12 +8,14 @@ import * as loader from "../../load-tf";
 /* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
 
-// **CONSTANTS:**
+/* CONSTANTS: */
 const SHAPE: [number, number] = [2, 2];
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
 
 /* -- tf.TensorBuffer class methods-- */
 export function run() {
-  // **HOOKS:**
+  /* HOOKS: */
   before((done) => {
     loader.load().then((result: loader.TFModule) => {
       tf = result;
@@ -27,7 +29,7 @@ export function run() {
     buffer = tf.buffer(SHAPE);
   });
 
-  // **TESTS:**
+  /* TESTS: */
   it("  -- TensorBuffer.set()", () => {
     buffer.set(4, 0, 1);
     const t: tfTypes.Tensor<tfTypes.Rank.R2> = buffer.toTensor();

--- a/apitests/src/tensors/classes/TensorBuffer.ts
+++ b/apitests/src/tensors/classes/TensorBuffer.ts
@@ -5,13 +5,14 @@ chai.use(tensorChaiPlugin);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
+/* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
+
+// **CONSTANTS:**
+const SHAPE: [number, number] = [2, 2];
 
 /* -- tf.TensorBuffer class methods-- */
 export function run() {
-  // **CONSTANTS:**
-  const SHAPE: [number, number] = [2, 2];
-
   // **HOOKS:**
   before((done) => {
     loader.load().then((result: loader.TFModule) => {

--- a/apitests/src/tensors/classes/Variable.ts
+++ b/apitests/src/tensors/classes/Variable.ts
@@ -18,11 +18,11 @@ type TensorShape =
   | [number, number, number, number, number]
   | [number, number, number, number, number, number];
 
-/* MOCHA TEST FUNCTION: */
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
 
 /* -- tf.Variable class methods-- */
 export function run() {
-  // **CONSTANTS:**
+  /* CONSTANTS: */
   const INITIAL = [1, 2, 3];
   const NEW_VALUES = [4, 5, 6];
   const BAD_NEW_VALUES = [
@@ -30,7 +30,7 @@ export function run() {
     [9, 10],
   ];
 
-  // **HOOKS:**
+  /* HOOKS: */
   before((done) => {
     loader.load().then((result: loader.TFModule) => {
       tf = result;
@@ -48,7 +48,7 @@ export function run() {
     x = tf.variable(t);
   });
 
-  // **TESTS:**
+  /* TESTS: */
   it("  -- Variable.assign()", () => {
     /*
     Assign a new tf.Tensor to this variable.

--- a/apitests/src/tensors/classes/Variable.ts
+++ b/apitests/src/tensors/classes/Variable.ts
@@ -4,19 +4,11 @@ import { tensorChaiPlugin } from "../../plugins/tensor-chai";
 chai.use(tensorChaiPlugin);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
+// Types
+import { TFArray } from "../../utils/tensor-utils";
 
 /* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
-
-/* TYPES: */
-type TensorShape =
-  | number[]
-  | [number]
-  | [number, number]
-  | [number, number, number]
-  | [number, number, number, number]
-  | [number, number, number, number, number]
-  | [number, number, number, number, number, number];
 
 /**** ---- MOCHA TEST FUNCTION: ---- *****/
 
@@ -40,7 +32,7 @@ export function run() {
   });
   // - to initialize before each test:
   let t: tfTypes.Tensor;
-  let tShape: TensorShape;
+  let tShape: TFArray;
   let x: tfTypes.Variable;
   beforeEach(() => {
     t = tf.tensor(INITIAL);

--- a/apitests/src/tensors/classes/Variable.ts
+++ b/apitests/src/tensors/classes/Variable.ts
@@ -5,9 +5,10 @@ chai.use(tensorChaiPlugin);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
+/* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
 
-// Types:
+/* TYPES: */
 type TensorShape =
   | number[]
   | [number]
@@ -16,6 +17,8 @@ type TensorShape =
   | [number, number, number, number]
   | [number, number, number, number, number]
   | [number, number, number, number, number, number];
+
+/* MOCHA TEST FUNCTION: */
 
 /* -- tf.Variable class methods-- */
 export function run() {

--- a/apitests/src/tensors/classes/Variable.ts
+++ b/apitests/src/tensors/classes/Variable.ts
@@ -7,6 +7,16 @@ import * as loader from "../../load-tf";
 
 let tf: loader.TFModule;
 
+// Types:
+type TensorShape =
+  | number[]
+  | [number]
+  | [number, number]
+  | [number, number, number]
+  | [number, number, number, number]
+  | [number, number, number, number, number]
+  | [number, number, number, number, number, number];
+
 /* -- tf.Variable class methods-- */
 export function run() {
   // **CONSTANTS:**
@@ -27,9 +37,11 @@ export function run() {
   });
   // - to initialize before each test:
   let t: tfTypes.Tensor;
+  let tShape: TensorShape;
   let x: tfTypes.Variable;
   beforeEach(() => {
     t = tf.tensor(INITIAL);
+    tShape = t.shape;
     x = tf.variable(t);
   });
 
@@ -49,6 +61,8 @@ export function run() {
     The new tensor does not have the same shape and dtype as the old tf.Tensor.
     */
     const t2: tfTypes.Tensor = tf.tensor(BAD_NEW_VALUES);
-    expect(() => x.assign(t2)).to.throw(Error);
+    expect(() => x.assign(t2)).to.throw(
+      `shape of the new value (${t2.shape}) and previous value (${tShape}) must match`
+    );
   });
 }

--- a/apitests/src/tensors/classes/Variable.ts
+++ b/apitests/src/tensors/classes/Variable.ts
@@ -1,0 +1,54 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+let tf: loader.TFModule;
+
+/* -- tf.Variable class methods-- */
+export function run() {
+  // **CONSTANTS:**
+  const INITIAL = [1, 2, 3];
+  const NEW_VALUES = [4, 5, 6];
+  const BAD_NEW_VALUES = [
+    [7, 8],
+    [9, 10],
+  ];
+
+  // **HOOKS:**
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+  // - to initialize before each test:
+  let t: tfTypes.Tensor;
+  let x: tfTypes.Variable;
+  beforeEach(() => {
+    t = tf.tensor(INITIAL);
+    x = tf.variable(t);
+  });
+
+  // **TESTS:**
+  it("  -- Variable.assign()", () => {
+    /*
+    Assign a new tf.Tensor to this variable.
+    The new tf.Tensor must have the same shape and dtype as the old tf.Tensor.
+    */
+    const t2: tfTypes.Tensor = tf.tensor(NEW_VALUES);
+    x.assign(t2);
+    expect(x).to.haveShape(t2.shape);
+    expect(x).to.lookLike(NEW_VALUES);
+  });
+  it("  -- Variable.assign() : bad shape", () => {
+    /*
+    The new tensor does not have the same shape and dtype as the old tf.Tensor.
+    */
+    const t2: tfTypes.Tensor = tf.tensor(BAD_NEW_VALUES);
+    expect(() => x.assign(t2)).to.throw(Error);
+  });
+}

--- a/apitests/src/tensors/classes/index.spec.ts
+++ b/apitests/src/tensors/classes/index.spec.ts
@@ -5,15 +5,21 @@ import spies from "chai-spies";
 chai.use(spies);
 import * as Tensor from "./Tensor";
 import * as Variable from "./Variable";
+import * as TensorBuffer from "./TensorBuffer";
 
 /* ---- Creating Tensors: tf classes related to tensors ---- */
 describe("**** TENSORS: Classes ****", () => {
   /* ---- tf.Tensor class---- *
-  A tf.Tensor object represents an immutable, multidimensional array of numbers that has a shape and a data type.
+    A tf.Tensor object represents an immutable, multidimensional array of numbers that has a shape and a data type.
   */
   describe("tf.Tensor : class", Tensor.run);
   /* ---- tf.Variable class---- *
-  A mutable tf.Tensor, useful for persisting state, e.g. for training.
+    A mutable tf.Tensor, useful for persisting state, e.g. for training.
   */
   describe("tf.Variable : class", Variable.run);
+  /* ---- tf.TensorBuffer class---- *
+    A mutable object, similar to tf.Tensor, that allows users to set values at locations before converting to an immutable tf.Tensor.
+    See tf.buffer() for creating a tensor buffer.
+  */
+  describe("tf.TensorBuffer : class", TensorBuffer.run);
 });

--- a/apitests/src/tensors/classes/index.spec.ts
+++ b/apitests/src/tensors/classes/index.spec.ts
@@ -4,11 +4,16 @@ chai.use(tensorChaiPlugin);
 import spies from "chai-spies";
 chai.use(spies);
 import * as Tensor from "./Tensor";
+import * as Variable from "./Variable";
 
 /* ---- Creating Tensors: tf classes related to tensors ---- */
 describe("**** TENSORS: Classes ****", () => {
   /* ---- tf.Tensor class---- *
   A tf.Tensor object represents an immutable, multidimensional array of numbers that has a shape and a data type.
   */
-  describe("tf.Tensor(start, stop, num):", Tensor.run.bind(this));
+  describe("tf.Tensor : class", Tensor.run);
+  /* ---- tf.Variable class---- *
+  A mutable tf.Tensor, useful for persisting state, e.g. for training.
+  */
+  describe("tf.Variable : class", Variable.run);
 });

--- a/apitests/src/tensors/creation/oneHot.ts
+++ b/apitests/src/tensors/creation/oneHot.ts
@@ -83,8 +83,8 @@ export function run() {
   it("  -- dType", async () => {
     //CONSTANTS
     const RESULT = [
-      [1, 0, 0],
-      [0, 1, 0],
+      [true, false, false],
+      [false, true, false],
     ];
     // TESTS
     const x: tfTypes.Tensor = tf.tensor(INDICES, undefined, "int32");

--- a/apitests/src/tensors/transformations/batchToSpaceND.ts
+++ b/apitests/src/tensors/transformations/batchToSpaceND.ts
@@ -1,0 +1,156 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+// utils
+import { areEqual } from "../../utils/tensor-utils";
+
+let tf: loader.TFModule;
+
+/* -- tf.Variable class methods-- */
+export function run() {
+  /* **HOOKS:** */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* **CONSTANTS:** */
+  const BLOCK_SHAPE = [2, 2];
+  const CROPS = [
+    [0, 0],
+    [0, 0],
+  ];
+
+  /* **TESTS:** */
+
+  // the innermost dimension is unchanged
+  // the middle dimensions get modified by the blockshape
+  // the rannk of the tensor remains unchanged
+  // the size of the tensor remains unchanged
+
+  it("  -- default example: shape [4, 1, 1, 1] --> [1, 2, 2, 1]", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
+    const expectedShape = [1, 2, 2, 1];
+    const expectedResult = [
+      [
+        [[1], [2]],
+        [[3], [4]],
+      ],
+    ];
+    const x: tfTypes.Tensor = t.batchToSpaceND(BLOCK_SHAPE, CROPS);
+    expect(x).to.haveShape(expectedShape);
+    expect(x).to.lookLike(expectedResult);
+  });
+  it("  -- shape [4, 1, 1, 3] --> [1, 2, 2, 3]", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      [4, 1, 1, 3]
+    );
+    const expectedShape = [1, 2, 2, 3];
+    const expectedResult = [
+      [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        [
+          [7, 8, 9],
+          [10, 11, 12],
+        ],
+      ],
+    ];
+    const x: tfTypes.Tensor = t.batchToSpaceND(BLOCK_SHAPE, CROPS);
+    expect(x).to.haveShape(expectedShape);
+    expect(x).to.lookLike(expectedResult);
+  });
+  it("  -- default : bad blockShape - not evenly divisible", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
+    const badBlockShape = [2, 3];
+    expect(() => t.batchToSpaceND(badBlockShape, CROPS)).to.throw(
+      `input tensor batch is 4 but is not divisible by the product of the elements of blockShape 2 * 3 === 6`
+    );
+  });
+  it("  -- default: blockShape that returns original tensor", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
+    const x: tfTypes.Tensor = t.batchToSpaceND(BLOCK_SHAPE, CROPS);
+    expect(areEqual(x, t)).to.be.true;
+  });
+  it("  -- shape [8, 1, 3, 1] --> [2, 2, 6, 1]", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d(
+      [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24,
+      ],
+      [8, 1, 3, 1]
+    );
+    const expectedShape = [2, 2, 6, 1];
+    const expectedResult = [
+      [
+        [[1], [7], [2], [8], [3], [9]],
+
+        [[13], [19], [14], [20], [15], [21]],
+      ],
+
+      [
+        [[4], [10], [5], [11], [6], [12]],
+
+        [[16], [22], [17], [23], [18], [24]],
+      ],
+    ];
+    const x: tfTypes.Tensor = t.batchToSpaceND(BLOCK_SHAPE, CROPS);
+    expect(x).to.haveShape(expectedShape);
+    expect(x).to.lookLike(expectedResult);
+  });
+  it("  -- bad crops : offest results in null tensor", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
+    const badCrops = [
+      [1, 1],
+      [1, 1],
+    ];
+    // shape has a 0 in 1st dimension, so first dimension will be null
+    // and will have no further dimensions or values
+    // ie. will result in empy array []
+    const expectedShape = [1, 0, 0, 1];
+    const expectedResult: number[] = [];
+    const x: tfTypes.Tensor = t.batchToSpaceND(BLOCK_SHAPE, badCrops);
+    expect(x).to.haveShape(expectedShape);
+    expect(x).to.lookLike(expectedResult);
+  });
+  it("  -- bad crops : crops of wrong shape", () => {
+    const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
+    // inner dimension should have length of 2 to reflect shape of tensor
+    const badCrops = [[0], [0]];
+    const expectedShape = [1, 0, 0, 1];
+    const expectedResult: number[] = [];
+    expect(() => t.batchToSpaceND(BLOCK_SHAPE, badCrops)).to.throw(
+      `Negative size values should be exactly -1 but got NaN for the slice() size at index 1.`
+    );
+  });
+  it("  -- with 2d tensor: blockshape = [2]; shape [2, 2] => [1, 4]", () => {
+    const t: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+    const newBlockShape = [2];
+    const newCrops = [[0, 0]];
+    const expectedShape = [1, 4];
+    const expectedResult = [[1, 3, 2, 4]]; //NB: this is different
+    const x: tfTypes.Tensor = t.batchToSpaceND(newBlockShape, newCrops);
+    expect(x).to.haveShape(expectedShape);
+    expect(x).to.lookLike(expectedResult);
+  });
+  it("  -- with 2d tensor: blockshape = [2]; shape [2, 2] => [1, 4]", () => {
+    const t: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+    const newBlockShape = [1];
+    const newCrops = [[0, 0]];
+    const expectedShape = [1, 4];
+    const expectedResult = [[1, 3, 2, 4]]; //NB: this is different
+    const x: tfTypes.Tensor = t.batchToSpaceND(newBlockShape, newCrops);
+    x.print();
+    // expect(x).to.haveShape(expectedShape);
+    // expect(x).to.lookLike(expectedResult);
+  });
+}

--- a/apitests/src/tensors/transformations/batchToSpaceND.ts
+++ b/apitests/src/tensors/transformations/batchToSpaceND.ts
@@ -17,11 +17,11 @@ const CROPS = [
   [0, 0],
 ];
 
-/* MOCHA TEST FUNCTION: */
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
 
 /* -- tf.Variable class methods-- */
 export function run() {
-  /* **HOOKS:** */
+  /* HOOKS: */
   before((done) => {
     loader.load().then((result: loader.TFModule) => {
       tf = result;
@@ -30,7 +30,7 @@ export function run() {
     });
   });
 
-  /* **TESTS:** */
+  /* TESTS: */
 
   // the innermost dimension is unchanged
   // the middle dimensions get modified by the blockshape

--- a/apitests/src/tensors/transformations/batchToSpaceND.ts
+++ b/apitests/src/tensors/transformations/batchToSpaceND.ts
@@ -7,7 +7,17 @@ import * as loader from "../../load-tf";
 // utils
 import { areEqual } from "../../utils/tensor-utils";
 
+/* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
+
+/* CONSTANTS: */
+const BLOCK_SHAPE = [2, 2];
+const CROPS = [
+  [0, 0],
+  [0, 0],
+];
+
+/* MOCHA TEST FUNCTION: */
 
 /* -- tf.Variable class methods-- */
 export function run() {
@@ -19,13 +29,6 @@ export function run() {
       done();
     });
   });
-
-  /* **CONSTANTS:** */
-  const BLOCK_SHAPE = [2, 2];
-  const CROPS = [
-    [0, 0],
-    [0, 0],
-  ];
 
   /* **TESTS:** */
 

--- a/apitests/src/tensors/transformations/batchToSpaceND.ts
+++ b/apitests/src/tensors/transformations/batchToSpaceND.ts
@@ -126,8 +126,6 @@ export function run() {
     const t: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
     // inner dimension should have length of 2 to reflect shape of tensor
     const badCrops = [[0], [0]];
-    const expectedShape = [1, 0, 0, 1];
-    const expectedResult: number[] = [];
     expect(() => t.batchToSpaceND(BLOCK_SHAPE, badCrops)).to.throw(
       `Negative size values should be exactly -1 but got NaN for the slice() size at index 1.`
     );
@@ -141,16 +139,5 @@ export function run() {
     const x: tfTypes.Tensor = t.batchToSpaceND(newBlockShape, newCrops);
     expect(x).to.haveShape(expectedShape);
     expect(x).to.lookLike(expectedResult);
-  });
-  it("  -- with 2d tensor: blockshape = [2]; shape [2, 2] => [1, 4]", () => {
-    const t: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-    const newBlockShape = [1];
-    const newCrops = [[0, 0]];
-    const expectedShape = [1, 4];
-    const expectedResult = [[1, 3, 2, 4]]; //NB: this is different
-    const x: tfTypes.Tensor = t.batchToSpaceND(newBlockShape, newCrops);
-    x.print();
-    // expect(x).to.haveShape(expectedShape);
-    // expect(x).to.lookLike(expectedResult);
   });
 }

--- a/apitests/src/tensors/transformations/batchToSpaceND.ts
+++ b/apitests/src/tensors/transformations/batchToSpaceND.ts
@@ -19,7 +19,7 @@ const CROPS = [
 
 /**** ---- MOCHA TEST FUNCTION: ---- *****/
 
-/* -- tf.Variable class methods-- */
+/* -- tf.batchToSpaceND(x, blockShape, crops)-- */
 export function run() {
   /* HOOKS: */
   before((done) => {

--- a/apitests/src/tensors/transformations/broadcastArgs.ts
+++ b/apitests/src/tensors/transformations/broadcastArgs.ts
@@ -1,0 +1,74 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/* CONSTANTS: */
+const EXAMPLES_2D = [
+  {
+    s0: [2, 2],
+    s1: [2, 1],
+    expectedShape: [2, 2],
+  },
+  {
+    s0: [1, 2],
+    s1: [2, 2],
+    expectedShape: [2, 2],
+  },
+  {
+    s0: [1, 2],
+    s1: [2, 1],
+    expectedShape: [2, 2],
+  },
+];
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.broadcastArgs (s0, s1)--
+  Return the shape of s0 op s1 with broadcast.
+  s0 and s1 represent shapes
+ */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+  it("  -- 2d examples: [2, n], [n, 2] => [2, 2]; n∈{1, 2}", () => {
+    EXAMPLES_2D.forEach(({ s0, s1, expectedShape }) => {
+      const t: tfTypes.Tensor = tf.broadcastArgs(s0, s1);
+      expect(t).to.lookLike(expectedShape);
+    });
+  });
+  it("  -- bad 2d example: n >= 3", () => {
+    const s0 = [1, 2];
+    const s1 = [2, 3];
+    expect(() => tf.broadcastArgs(s0, s1)).to.throw(
+      `Operands could not be broadcast together with shapes 1,2 and 2,3.`
+    );
+  });
+  it("  -- 2d example (passing but bad): if s0, s1 are floats, they are truncated to ints", () => {
+    const s0 = [1.2, 2.5];
+    const s1 = [2.3, 1];
+    const expectedShape = [2, 2];
+    const t: tfTypes.Tensor = tf.broadcastArgs(s0, s1);
+    expect(t).to.lookLike(expectedShape);
+  });
+  it("  -- 3d example: [2, 3], [3, 2, 3] => [2, 2]", () => {
+    const s0 = [2, 3];
+    const s1 = [3, 2, 3];
+    const expectedShape = [3, 2, 3];
+    const t: tfTypes.Tensor = tf.broadcastArgs(s0, s1);
+    expect(t).to.lookLike(expectedShape);
+  });
+}

--- a/apitests/src/tensors/transformations/broadcastTo.ts
+++ b/apitests/src/tensors/transformations/broadcastTo.ts
@@ -48,7 +48,7 @@ export function run() {
     const t: tfTypes.Tensor = tf.broadcastTo(x, DEFAULT_BROADCAST_SHAPE);
     expect(t).to.lookLike(DEFAULT_EXPECTED_RESULT);
   });
-  it("  -- tensor=>tensor : 2d example", () => {
+  it("  -- 2d example : shape [3, 3] => [2, 3, 3] ", () => {
     const arr = [
       [1, 2, 3],
       [4, 5, 6],
@@ -67,6 +67,17 @@ export function run() {
         [4, 5, 6],
         [7, 8, 9],
       ],
+    ];
+    const x: tfTypes.Tensor<tfTypes.Rank.R1> = tf.tensor(arr);
+    const t: tfTypes.Tensor = tf.broadcastTo(x, broadcastShape);
+    expect(t).to.lookLike(expectedResult);
+  });
+  it("  -- if array has shape if smaller dimension, it will copy that value : shape [2, 1] => [2, 2] ", () => {
+    const arr = [[5], [6]];
+    const broadcastShape = [2, 2];
+    const expectedResult = [
+      [5, 5],
+      [6, 6],
     ];
     const x: tfTypes.Tensor<tfTypes.Rank.R1> = tf.tensor(arr);
     const t: tfTypes.Tensor = tf.broadcastTo(x, broadcastShape);

--- a/apitests/src/tensors/transformations/broadcastTo.ts
+++ b/apitests/src/tensors/transformations/broadcastTo.ts
@@ -1,0 +1,71 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+let tf: loader.TFModule;
+
+/* -- tf.Variable class methods-- */
+export function run() {
+  // **HOOKS:**
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  // **CONSTANTS:**
+  const DEFAULT_ARR = [1, 2, 3];
+  const DEFAULT_BROADCAST_SHAPE = [2, 3];
+  const DEFAULT_EXPECTED_RESULT = [
+    [1, 2, 3],
+    [1, 2, 3],
+  ];
+  // **TESTS:**
+  it("  -- array=>tensor : default example", () => {
+    const t: tfTypes.Tensor = tf.broadcastTo(
+      DEFAULT_ARR,
+      DEFAULT_BROADCAST_SHAPE
+    );
+    expect(t).to.lookLike(DEFAULT_EXPECTED_RESULT);
+  });
+  it("  -- array=>tensor : incompatible shape - number of columns must match", () => {
+    const arr = [1, 1, 1, 1]; // shape = [4]
+    expect(() => tf.broadcastTo(arr, DEFAULT_BROADCAST_SHAPE)).to.throw(
+      `broadcastTo(): [4] cannot be broadcast to [2,3].`
+    );
+  });
+  it("  -- tensor=>tensor : default example", () => {
+    const x: tfTypes.Tensor<tfTypes.Rank.R1> = tf.tensor(DEFAULT_ARR);
+    const t: tfTypes.Tensor = tf.broadcastTo(x, DEFAULT_BROADCAST_SHAPE);
+    expect(t).to.lookLike(DEFAULT_EXPECTED_RESULT);
+  });
+  it("  -- tensor=>tensor : 2d example", () => {
+    const arr = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    const broadcastShape = [2, 3, 3];
+    const expectedResult = [
+      [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+
+      [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    ];
+    const x: tfTypes.Tensor<tfTypes.Rank.R1> = tf.tensor(arr);
+    const t: tfTypes.Tensor = tf.broadcastTo(x, broadcastShape);
+    expect(t).to.lookLike(expectedResult);
+  });
+}

--- a/apitests/src/tensors/transformations/broadcastTo.ts
+++ b/apitests/src/tensors/transformations/broadcastTo.ts
@@ -16,11 +16,11 @@ const DEFAULT_EXPECTED_RESULT = [
   [1, 2, 3],
 ];
 
-/* MOCHA TEST FUNCTION: */
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
 
 /* -- tf.Variable class methods-- */
 export function run() {
-  // **HOOKS:**
+  /* HOOKS: */
   before((done) => {
     loader.load().then((result: loader.TFModule) => {
       tf = result;
@@ -29,7 +29,7 @@ export function run() {
     });
   });
 
-  // **TESTS:**
+  /* TESTS: */
   it("  -- array=>tensor : default example", () => {
     const t: tfTypes.Tensor = tf.broadcastTo(
       DEFAULT_ARR,

--- a/apitests/src/tensors/transformations/broadcastTo.ts
+++ b/apitests/src/tensors/transformations/broadcastTo.ts
@@ -5,7 +5,18 @@ chai.use(tensorChaiPlugin);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
+/* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
+
+/* CONSTANTS: */
+const DEFAULT_ARR = [1, 2, 3];
+const DEFAULT_BROADCAST_SHAPE = [2, 3];
+const DEFAULT_EXPECTED_RESULT = [
+  [1, 2, 3],
+  [1, 2, 3],
+];
+
+/* MOCHA TEST FUNCTION: */
 
 /* -- tf.Variable class methods-- */
 export function run() {
@@ -18,13 +29,6 @@ export function run() {
     });
   });
 
-  // **CONSTANTS:**
-  const DEFAULT_ARR = [1, 2, 3];
-  const DEFAULT_BROADCAST_SHAPE = [2, 3];
-  const DEFAULT_EXPECTED_RESULT = [
-    [1, 2, 3],
-    [1, 2, 3],
-  ];
   // **TESTS:**
   it("  -- array=>tensor : default example", () => {
     const t: tfTypes.Tensor = tf.broadcastTo(

--- a/apitests/src/tensors/transformations/broadcastTo.ts
+++ b/apitests/src/tensors/transformations/broadcastTo.ts
@@ -18,7 +18,7 @@ const DEFAULT_EXPECTED_RESULT = [
 
 /**** ---- MOCHA TEST FUNCTION: ---- *****/
 
-/* -- tf.Variable class methods-- */
+/* -- tf.broadcastTo (x, shape)-- */
 export function run() {
   /* HOOKS: */
   before((done) => {

--- a/apitests/src/tensors/transformations/cast.ts
+++ b/apitests/src/tensors/transformations/cast.ts
@@ -1,0 +1,43 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.cast (x, dtype)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+  it("  -- float to int ", () => {
+    const x: tfTypes.Tensor1D = tf.tensor1d([1.5, 2.5, 3]);
+    const y: tfTypes.Tensor1D = tf.cast(x, "int32");
+    const expected = [1, 2, 3];
+    expect(y).to.haveDtype("int32");
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- float to bool ", () => {
+    // 0 gets cast to false, everything else to true
+    const x: tfTypes.Tensor2D = tf.tensor2d([1.5, 2.5, 0, 3], [2, 2]);
+    const y: tfTypes.Tensor1D = tf.cast(x, "bool");
+    const expected = [
+      [1, 1],
+      [0, 1],
+    ];
+    expect(y).to.haveDtype("bool");
+    expect(y.arraySync()).to.eql(expected);
+  });
+}

--- a/apitests/src/tensors/transformations/cast.ts
+++ b/apitests/src/tensors/transformations/cast.ts
@@ -22,22 +22,63 @@ export function run() {
   });
 
   /* TESTS: */
-  it("  -- float to int ", () => {
+  it("  -- float to int", () => {
     const x: tfTypes.Tensor1D = tf.tensor1d([1.5, 2.5, 3]);
     const y: tfTypes.Tensor1D = tf.cast(x, "int32");
     const expected = [1, 2, 3];
     expect(y).to.haveDtype("int32");
     expect(y).to.lookLike(expected);
   });
-  it("  -- float to bool ", () => {
+  it("  -- float to bool", () => {
     // 0 gets cast to false, everything else to true
     const x: tfTypes.Tensor2D = tf.tensor2d([1.5, 2.5, 0, 3], [2, 2]);
-    const y: tfTypes.Tensor1D = tf.cast(x, "bool");
+    const y: tfTypes.Tensor2D = tf.cast(x, "bool");
     const expected = [
-      [1, 1],
-      [0, 1],
+      [true, true],
+      [false, true],
     ];
     expect(y).to.haveDtype("bool");
-    expect(y.arraySync()).to.eql(expected);
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- float to bool", () => {
+    // 0 gets cast to false, everything else to true
+    const x: tfTypes.Tensor3D = tf.tensor3d(
+      [1.5, 2.5, 0, 3, 0.2, 0, 20, 0],
+      [2, 2, 2]
+    );
+    const y: tfTypes.Tensor3D = tf.cast(x, "bool");
+    const expected = [
+      [
+        [true, true],
+        [false, true],
+      ],
+
+      [
+        [true, false],
+        [true, false],
+      ],
+    ];
+    expect(y).to.haveDtype("bool");
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- float to string : throws error ", () => {
+    const x: tfTypes.Tensor1D = tf.tensor1d([1.5, 2.5, 3]);
+    expect(() => tf.cast(x, "string")).to.throw(
+      `Only strings can be casted to strings`
+    );
+  });
+  it("  -- int to float", () => {
+    const x: tfTypes.Tensor1D = tf.tensor1d([1, 2, 3], "int32");
+    const y: tfTypes.Tensor1D = tf.cast(x, "float32");
+    const expected = [1, 2, 3];
+    expect(y).to.haveDtype("float32");
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- int to bool", () => {
+    const x: tfTypes.Tensor1D = tf.tensor1d([1, 0, 3], "int32");
+    const y: tfTypes.Tensor1D = tf.cast(x, "bool");
+    const expected = [true, false, true];
+    expect(y).to.haveDtype("bool");
+    expect(y).to.lookLike(expected);
   });
 }

--- a/apitests/src/tensors/transformations/depthToSpace.ts
+++ b/apitests/src/tensors/transformations/depthToSpace.ts
@@ -10,7 +10,7 @@ let tf: loader.TFModule;
 
 /**** ---- MOCHA TEST FUNCTION: ---- *****/
 
-/* -- tf.batchToSpaceND(x, blockShape, crops)-- */
+/* -- tf.depthToSpace (x, blockSize, dataFormat?)-- */
 export function run() {
   /* HOOKS: */
   before((done) => {
@@ -22,11 +22,6 @@ export function run() {
   });
 
   /* TESTS: */
-
-  // the innermost dimension is unchanged
-  // the middle dimensions get modified by the blockshape
-  // the rannk of the tensor remains unchanged
-  // the size of the tensor remains unchanged
 
   it("  -- shape [1, 1, 1, 4], blockSize 2 => [1, 2, 2, 1]", () => {
     const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 1, 1, 4]);

--- a/apitests/src/tensors/transformations/depthToSpace.ts
+++ b/apitests/src/tensors/transformations/depthToSpace.ts
@@ -1,0 +1,71 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.batchToSpaceND(x, blockShape, crops)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  // the innermost dimension is unchanged
+  // the middle dimensions get modified by the blockshape
+  // the rannk of the tensor remains unchanged
+  // the size of the tensor remains unchanged
+
+  it("  -- shape [1, 1, 1, 4], blockSize 2 => [1, 2, 2, 1]", () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 1, 1, 4]);
+    const blockSize = 2;
+    const expected = [
+      [
+        [[1], [2]],
+
+        [[3], [4]],
+      ],
+    ];
+    const y: tfTypes.Tensor4D = tf.depthToSpace(x, blockSize);
+    expect(y).to.haveShape([1, 2, 2, 1]);
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- shape [1, 1, 1, 9] blockSize 3 => [1, 2, 2, 1]", () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [1, 1, 1, 9]
+    );
+    const blockSize = 3;
+    const expected = [
+      [
+        [[1], [2], [3]],
+
+        [[4], [5], [6]],
+
+        [[7], [8], [9]],
+      ],
+    ];
+    const y: tfTypes.Tensor4D = tf.depthToSpace(x, blockSize);
+    expect(y).to.haveShape([1, 3, 3, 1]);
+    expect(y).to.lookLike(expected);
+  });
+  it("  -- error : dimension size not divisible by block size", () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 1, 1, 4]);
+    const blockSize = 3;
+    expect(() => tf.depthToSpace(x, blockSize)).to.throw(
+      `Dimension size must be evenly divisible by 9 but is 4 for depthToSpace with input shape 1,1,1,4`
+    );
+  });
+}

--- a/apitests/src/tensors/transformations/ensureShape.ts
+++ b/apitests/src/tensors/transformations/ensureShape.ts
@@ -2,7 +2,6 @@ import * as chai from "chai";
 const expect = chai.expect;
 import { tensorChaiPlugin } from "../../plugins/tensor-chai";
 chai.use(tensorChaiPlugin);
-import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
 /* MODULE TO LOAD DYNAMICALLY: */

--- a/apitests/src/tensors/transformations/ensureShape.ts
+++ b/apitests/src/tensors/transformations/ensureShape.ts
@@ -1,0 +1,29 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.ensureShape (x, shape)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  it("  -- function does not exist in tfjs", () => {
+    expect(tf).to.not.include.keys("ensureShape");
+  });
+}

--- a/apitests/src/tensors/transformations/expandDims.ts
+++ b/apitests/src/tensors/transformations/expandDims.ts
@@ -46,4 +46,12 @@ export function run() {
     expect(y).to.haveShape(expectedShape);
     expect(y).to.lookLike(expectedValue);
   });
+  it("  -- bad 2d example : with axis out of range", () => {
+    const axis = 3;
+    const initialShape: [number, number] = [2, 2];
+    const x: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], initialShape);
+    expect(() => x.expandDims(axis)).to.throw(
+      `Axis must be <= rank of the tensor`
+    );
+  });
 }

--- a/apitests/src/tensors/transformations/expandDims.ts
+++ b/apitests/src/tensors/transformations/expandDims.ts
@@ -1,0 +1,49 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.expandDims (x, axis?)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  it("  -- 1d example", () => {
+    const x: tfTypes.Tensor1D = tf.tensor1d([1, 2, 3, 4]);
+    const expectedShape = [1, 4];
+    const y: tfTypes.Tensor = x.expandDims();
+    expect(y).to.haveShape(expectedShape);
+  });
+  it("  -- 2d example", () => {
+    const initialShape: [number, number] = [2, 2];
+    const expectedShape = [1, 2, 2];
+    const x: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], initialShape);
+    const y: tfTypes.Tensor = x.expandDims();
+    expect(y).to.haveShape(expectedShape);
+  });
+  it("  -- 2d example : with axis", () => {
+    const axis = 1;
+    const initialShape: [number, number] = [2, 2];
+    const expectedShape = [2, 1, 2];
+    const expectedValue = [[[1, 2]], [[3, 4]]];
+    const x: tfTypes.Tensor2D = tf.tensor2d([1, 2, 3, 4], initialShape);
+    const y: tfTypes.Tensor = x.expandDims(axis);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedValue);
+  });
+}

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -16,6 +16,7 @@ import * as pad from "./pad";
 import * as reshape from "./reshape";
 import * as setdiff1dAsync from "./setdiff1dAsync";
 import * as spaceToBatchND from "./spaceToBatchND";
+import * as squeeze from "./squeeze";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -110,4 +111,9 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     "tf.spaceToBatchND (x, blockShape, paddings) : transformation",
     spaceToBatchND.run
   );
+
+  /* ---- tf.squeeze (x, axis?)  ---- *
+    Removes dimensions of size 1 from the shape of a tf.Tensor.
+   */
+  describe("tf.squeeze (x, axis?) : transformation", squeeze.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -13,6 +13,7 @@ import * as ensureShape from "./ensureShape";
 import * as expandDims from "./expandDims";
 import * as mirrorPad from "./mirrorPad";
 import * as pad from "./pad";
+import * as reshape from "./reshape";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -80,4 +81,11 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     This operation implements CONSTANT mode. For REFLECT and SYMMETRIC, refer to tf.mirrorPad().
   */
   describe("tf.pad (x, paddings, constantValue?) : transformation", pad.run);
+
+  /* ---- tf.reshape (x, shape)  ---- *
+    Reshapes a tf.Tensor to a given shape.
+    Given an input tensor, returns a new tensor with the same values as the input tensor with shape shape.
+    If one component of shape is the special value -1, the size of that dimension is computed so that the total size remains constant. In particular, a shape of [-1] flattens into 1-D. At most one component of shape can be -1.
+  */
+  describe("tf.reshape (x, shape) : transformation", reshape.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -11,6 +11,7 @@ import * as cast from "./cast";
 import * as depthToSpace from "./depthToSpace";
 import * as ensureShape from "./ensureShape";
 import * as expandDims from "./expandDims";
+import * as mirrorPad from "./mirrorPad";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -66,4 +67,10 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     Returns a tf.Tensor that has expanded rank, by inserting a dimension into the tensor's shape.
   */
   describe("tf.expandDims (x, axis?) : transformation", expandDims.run);
+
+  /* ---- tf.mirrorPad (x, paddings, mode) ---- *
+    Pads a tf.Tensor using mirror padding.
+    This operation implements the REFLECT and SYMMETRIC modes of pad.
+  */
+  describe("tf.mirrorPad (x, paddings, mode) : transformation", mirrorPad.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -6,6 +6,7 @@ chai.use(spies);
 
 import * as batchToSpaceND from "./batchToSpaceND";
 import * as broadcastTo from "./broadcastTo";
+import * as broadcastArgs from "./broadcastArgs";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -25,4 +26,10 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     If input.shape[i]==1 and shape[i]==N, then the input tensor is tiled N times along that axis (using tf.tile).
   */
   describe("tf.broadcastTo (x, shape) : transformation", broadcastTo.run);
+  /* ---- tf.broadcastTo (x, shape) ---- *
+    Return the shape of s0 op s1 with broadcast.
+    compute r0, the broadcasted shape as a tensor. s0, s1 and r0 are all integer vectors.
+    This function returns the shape of the result of an operation between two tensors of size s0 and s1 performed with broadcast.
+  */
+  describe("tf.broadcastArgs (s0, s1) : transformation", broadcastArgs.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -10,6 +10,7 @@ import * as broadcastArgs from "./broadcastArgs";
 import * as cast from "./cast";
 import * as depthToSpace from "./depthToSpace";
 import * as ensureShape from "./ensureShape";
+import * as expandDims from "./expandDims";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -60,4 +61,9 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     The method supports the null value in tensor. It will still check the shapes, and null is a placeholder.
   */
   describe("tf.ensureShape (x, shape) : transformation", ensureShape.run);
+
+  /* ---- tf.expandDims (x, axis?) ---- *
+    Returns a tf.Tensor that has expanded rank, by inserting a dimension into the tensor's shape.
+  */
+  describe("tf.expandDims (x, axis?) : transformation", expandDims.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -14,6 +14,7 @@ import * as expandDims from "./expandDims";
 import * as mirrorPad from "./mirrorPad";
 import * as pad from "./pad";
 import * as reshape from "./reshape";
+import * as setdiff1dAsync from "./setdiff1dAsync";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -88,4 +89,12 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     If one component of shape is the special value -1, the size of that dimension is computed so that the total size remains constant. In particular, a shape of [-1] flattens into 1-D. At most one component of shape can be -1.
   */
   describe("tf.reshape (x, shape) : transformation", reshape.run);
+
+  /* ---- tf.setdiff1dAsync (x, y)  ---- *
+    Computes the difference between two lists of numbers.
+    Given a Tensor x and a Tensor y, this operation returns a Tensor out that represents all values that are in x but not in y.
+    The returned Tensor out is sorted in the same order that the numbers appear in x (duplicates are preserved).
+    This operation also returns a Tensor indices that represents the position of each out element in x. 
+  */
+  describe("tf.setdiff1dAsync (x, y) : transformation", setdiff1dAsync.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -8,6 +8,7 @@ import * as batchToSpaceND from "./batchToSpaceND";
 import * as broadcastTo from "./broadcastTo";
 import * as broadcastArgs from "./broadcastArgs";
 import * as cast from "./cast";
+import * as depthToSpace from "./depthToSpace";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -19,6 +20,7 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     "tf.batchToSpaceND(x, blockShape, crops) : transformation",
     batchToSpaceND.run
   );
+
   /* ---- tf.broadcastTo (x, shape) ---- *
     Broadcast an array to a compatible shape NumPy-style.
     The tensor's shape is compared to the broadcast shape from end to beginning.
@@ -27,14 +29,27 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     If input.shape[i]==1 and shape[i]==N, then the input tensor is tiled N times along that axis (using tf.tile).
   */
   describe("tf.broadcastTo (x, shape) : transformation", broadcastTo.run);
+
   /* ---- tf.broadcastTo (x, shape) ---- *
     Return the shape of s0 op s1 with broadcast.
     compute r0, the broadcasted shape as a tensor. s0, s1 and r0 are all integer vectors.
     This function returns the shape of the result of an operation between two tensors of size s0 and s1 performed with broadcast.
   */
   describe("tf.broadcastArgs (s0, s1) : transformation", broadcastArgs.run);
+
   /* ---- tf.broadcastTo (x, shape) ---- *
     Casts a tf.Tensor to a new dtype.
   */
   describe("tf.cast (x, dtype) : transformation", cast.run);
+
+  /* ---- tf.broadcastTo (x, shape) ---- *
+    Rearranges data from depth into blocks of spatial data.
+    More specifically, this op outputs a copy of the input tensor where values from the depth dimension are moved
+    in spatial blocks to the height and width dimensions.
+    The attr blockSize indicates the input block size and how the data is moved.
+  */
+  describe(
+    "tf.depthToSpace (x, blockSize, dataFormat?) : transformation",
+    depthToSpace.run
+  );
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -9,6 +9,7 @@ import * as broadcastTo from "./broadcastTo";
 import * as broadcastArgs from "./broadcastArgs";
 import * as cast from "./cast";
 import * as depthToSpace from "./depthToSpace";
+import * as ensureShape from "./ensureShape";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -52,4 +53,11 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     "tf.depthToSpace (x, blockSize, dataFormat?) : transformation",
     depthToSpace.run
   );
+
+  /* ---- tf.broadcastTo (x, shape) ---- *
+    Checks the input tensor mathes the given shape.
+    Given an input tensor, returns a new tensor with the same values as the input tensor with shape shape.
+    The method supports the null value in tensor. It will still check the shapes, and null is a placeholder.
+  */
+  describe("tf.ensureShape (x, shape) : transformation", ensureShape.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -1,0 +1,19 @@
+import * as chai from "chai";
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import spies from "chai-spies";
+chai.use(spies);
+
+import * as batchToSpaceND from "./batchToSpaceND";
+
+/* ---- Tensors: This section describes some common Tensor transformations for reshaping and type-casting.---- */
+describe("**** TENSORS: Transformation Methods ****", () => {
+  /* ---- tf.batchToSpaceND(x, blockShape, crops)---- *
+    This operation reshapes the "batch" dimension 0 into M + 1 dimensions of shape blockShape + [batch], interleaves these blocks back into the grid defined by the spatial dimensions [1, ..., M], to obtain a result with the same rank as the input.
+    The spatial dimensions of this intermediate result are then optionally cropped according to crops to produce the output.
+  */
+  describe(
+    "tf.batchToSpaceND(x, blockShape, crops) : transformation",
+    batchToSpaceND.run
+  );
+});

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -15,6 +15,7 @@ import * as mirrorPad from "./mirrorPad";
 import * as pad from "./pad";
 import * as reshape from "./reshape";
 import * as setdiff1dAsync from "./setdiff1dAsync";
+import * as spaceToBatchND from "./spaceToBatchND";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -97,4 +98,16 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     This operation also returns a Tensor indices that represents the position of each out element in x. 
   */
   describe("tf.setdiff1dAsync (x, y) : transformation", setdiff1dAsync.run);
+
+  /* ---- tf.spaceToBatchND (x, blockShape, paddings)  ---- *
+    This operation divides "spatial" dimensions [1, ..., M] of the input into a grid of blocks of shape blockShape,
+    and interleaves these blocks with the "batch" dimension (0) such that in the output,
+    the spatial dimensions [1, ..., M] correspond to the position within the grid,
+    and the batch dimension combines both the position within a spatial block and the original batch position.
+    Prior to division into blocks, the spatial dimensions of the input are optionally zero padded according to paddings.
+   */
+  describe(
+    "tf.spaceToBatchND (x, blockShape, paddings) : transformation",
+    spaceToBatchND.run
+  );
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -7,6 +7,7 @@ chai.use(spies);
 import * as batchToSpaceND from "./batchToSpaceND";
 import * as broadcastTo from "./broadcastTo";
 import * as broadcastArgs from "./broadcastArgs";
+import * as cast from "./cast";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -32,4 +33,8 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     This function returns the shape of the result of an operation between two tensors of size s0 and s1 performed with broadcast.
   */
   describe("tf.broadcastArgs (s0, s1) : transformation", broadcastArgs.run);
+  /* ---- tf.broadcastTo (x, shape) ---- *
+    Casts a tf.Tensor to a new dtype.
+  */
+  describe("tf.cast (x, dtype) : transformation", cast.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -5,8 +5,9 @@ import spies from "chai-spies";
 chai.use(spies);
 
 import * as batchToSpaceND from "./batchToSpaceND";
+import * as broadcastTo from "./broadcastTo";
 
-/* ---- Tensors: This section describes some common Tensor transformations for reshaping and type-casting.---- */
+/* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
   /* ---- tf.batchToSpaceND(x, blockShape, crops)---- *
     This operation reshapes the "batch" dimension 0 into M + 1 dimensions of shape blockShape + [batch], interleaves these blocks back into the grid defined by the spatial dimensions [1, ..., M], to obtain a result with the same rank as the input.
@@ -16,4 +17,12 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     "tf.batchToSpaceND(x, blockShape, crops) : transformation",
     batchToSpaceND.run
   );
+  /* ---- tf.broadcastTo (x, shape) ---- *
+    Broadcast an array to a compatible shape NumPy-style.
+    The tensor's shape is compared to the broadcast shape from end to beginning.
+    Ones are prepended to the tensor's shape until it has the same length as the broadcast shape.
+    If input.shape[i]==shape[i], the (i+1)-th axis is already broadcast-compatible.
+    If input.shape[i]==1 and shape[i]==N, then the input tensor is tiled N times along that axis (using tf.tile).
+  */
+  describe("tf.broadcastTo (x, shape) : transformation", broadcastTo.run);
 });

--- a/apitests/src/tensors/transformations/index.spec.ts
+++ b/apitests/src/tensors/transformations/index.spec.ts
@@ -12,6 +12,7 @@ import * as depthToSpace from "./depthToSpace";
 import * as ensureShape from "./ensureShape";
 import * as expandDims from "./expandDims";
 import * as mirrorPad from "./mirrorPad";
+import * as pad from "./pad";
 
 /* ---- Tensors - transformations: This section describes some common Tensor transformations for reshaping and type-casting.---- */
 describe("**** TENSORS: Transformation Methods ****", () => {
@@ -73,4 +74,10 @@ describe("**** TENSORS: Transformation Methods ****", () => {
     This operation implements the REFLECT and SYMMETRIC modes of pad.
   */
   describe("tf.mirrorPad (x, paddings, mode) : transformation", mirrorPad.run);
+
+  /* ---- tf.pad (x, paddings, constantValue?)  ---- *
+    Pads a tf.Tensor with a given value and paddings.
+    This operation implements CONSTANT mode. For REFLECT and SYMMETRIC, refer to tf.mirrorPad().
+  */
+  describe("tf.pad (x, paddings, constantValue?) : transformation", pad.run);
 });

--- a/apitests/src/tensors/transformations/mirrorPad.ts
+++ b/apitests/src/tensors/transformations/mirrorPad.ts
@@ -1,0 +1,164 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.mirrorPad (x, paddings, mode)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* CONSTANTS: */
+  const INPUT = [
+    [
+      [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+      ],
+    ],
+  ];
+
+  /* TESTS: */
+
+  it("  -- reflect: 3rd dimension", () => {
+    // input shape = [ 1, 1, 3, 3 ]
+    const outputShape = [1, 1, 7, 3];
+    const output = [
+      [
+        [
+          [6, 7, 8],
+          [3, 4, 5],
+          [0, 1, 2],
+          [3, 4, 5],
+          [6, 7, 8],
+          [3, 4, 5],
+          [0, 1, 2],
+        ],
+      ],
+    ];
+    const x: tfTypes.Tensor4D = tf.tensor4d(INPUT);
+    const y = x.mirrorPad(
+      [
+        [0, 0],
+        [0, 0],
+        [2, 2],
+        [0, 0],
+      ],
+      "reflect"
+    );
+    expect(y).to.haveShape(outputShape);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- reflect: 4th dimension", () => {
+    // input shape = [ 1, 1, 3, 3 ]
+    const outputShape = [1, 1, 3, 7];
+    const output = [
+      [
+        [
+          [2, 1, 0, 1, 2, 1, 0],
+          [5, 4, 3, 4, 5, 4, 3],
+          [8, 7, 6, 7, 8, 7, 6],
+        ],
+      ],
+    ];
+    const x: tfTypes.Tensor4D = tf.tensor4d(INPUT);
+    const y = x.mirrorPad(
+      [
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [2, 2],
+      ],
+      "reflect"
+    );
+    expect(y).to.haveShape(outputShape);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- reflect: 3rd and 4th dimensions", () => {
+    // input shape = [ 1, 1, 3, 3 ]
+    const outputShape = [1, 1, 7, 7];
+    const output = [
+      [
+        [
+          [8, 7, 6, 7, 8, 7, 6],
+          [5, 4, 3, 4, 5, 4, 3],
+          [2, 1, 0, 1, 2, 1, 0],
+          [5, 4, 3, 4, 5, 4, 3],
+          [8, 7, 6, 7, 8, 7, 6],
+          [5, 4, 3, 4, 5, 4, 3],
+          [2, 1, 0, 1, 2, 1, 0],
+        ],
+      ],
+    ];
+    const x: tfTypes.Tensor4D = tf.tensor4d(INPUT);
+    const y = x.mirrorPad(
+      [
+        [0, 0],
+        [0, 0],
+        [2, 2],
+        [2, 2],
+      ],
+      "reflect"
+    );
+    expect(y).to.haveShape(outputShape);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- bad reflect: paddings out of range", () => {
+    // input shape = [ 1, 1, 3, 3 ]
+    const x: tfTypes.Tensor4D = tf.tensor4d(INPUT);
+    const paddings: [number, number][] = [
+      [0, 0],
+      [0, 0],
+      [3, 3],
+      [0, 0],
+    ];
+    expect(() => x.mirrorPad(paddings, "reflect")).to.throw(
+      `Padding in dimension 2 cannot be greater than or equal to 2 or less than 0 for input of shape 1,1,3,3`
+    );
+  });
+  it("  -- symmetric : valid padding up to [3, 3]", () => {
+    // input shape = [ 1, 1, 3, 3 ]
+    const outputShape = [1, 1, 9, 3];
+    const output = [
+      [
+        [
+          [6, 7, 8],
+          [3, 4, 5],
+          [0, 1, 2],
+          [0, 1, 2],
+          [3, 4, 5],
+          [6, 7, 8],
+          [6, 7, 8],
+          [3, 4, 5],
+          [0, 1, 2],
+        ],
+      ],
+    ];
+    const x: tfTypes.Tensor4D = tf.tensor4d(INPUT);
+    const y = x.mirrorPad(
+      [
+        [0, 0],
+        [0, 0],
+        [3, 3],
+        [0, 0],
+      ],
+      "symmetric"
+    );
+    expect(y).to.haveShape(outputShape);
+    expect(y).to.lookLike(output);
+  });
+}

--- a/apitests/src/tensors/transformations/pad.ts
+++ b/apitests/src/tensors/transformations/pad.ts
@@ -25,8 +25,6 @@ export function run() {
     });
   });
 
-  /* CONSTANTS: */
-
   /* TESTS: */
 
   it("  -- default: pads with 0s", () => {

--- a/apitests/src/tensors/transformations/pad.ts
+++ b/apitests/src/tensors/transformations/pad.ts
@@ -1,0 +1,49 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* See also: src/tensors/transformations/mirrorPad.ts
+  for more thorough testing of padding
+*/
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.pad (x, paddings, constantValue?)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* CONSTANTS: */
+
+  /* TESTS: */
+
+  it("  -- default: pads with 0s", () => {
+    const input = [1, 2, 3, 4];
+    const padding: [number, number][] = [[1, 2]];
+    const output = [0, 1, 2, 3, 4, 0, 0];
+    const x: tfTypes.Tensor1D = tf.tensor1d(input);
+    const y: tfTypes.Tensor1D = x.pad(padding);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- constantValue: pads with constantValue", () => {
+    const constantValue = 9;
+    const input = [1, 2, 3, 4];
+    const padding: [number, number][] = [[1, 2]];
+    const output = [9, 1, 2, 3, 4, 9, 9];
+    const x: tfTypes.Tensor1D = tf.tensor1d(input);
+    const y: tfTypes.Tensor1D = x.pad(padding, constantValue);
+    expect(y).to.lookLike(output);
+  });
+}

--- a/apitests/src/tensors/transformations/reshape.ts
+++ b/apitests/src/tensors/transformations/reshape.ts
@@ -1,0 +1,87 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* See also: src/tensors/transformations/mirrorPad.ts
+  for more thorough testing of padding
+*/
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.reshape (x, shape)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  it("  -- default", () => {
+    const input = [1, 2, 3, 4];
+    const newShape = [2, 2];
+    const output = [
+      [1, 2],
+      [3, 4],
+    ];
+    const x: tfTypes.Tensor1D = tf.tensor1d(input);
+    const y: tfTypes.Tensor2D = x.reshape(newShape);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- with dimension set to -1", () => {
+    //input shape = [ 3, 2, 2 ]
+    const input = [
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      [
+        [5, 6],
+        [7, 8],
+      ],
+      [
+        [9, 10],
+        [11, 12],
+      ],
+    ];
+    const newShape = [4, -1];
+    // -1 should be inferred to 12/4 = 3
+    const expectedShape = [4, 3];
+    const output = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [10, 11, 12],
+    ];
+    const x: tfTypes.Tensor3D = tf.tensor3d(input);
+    const y: tfTypes.Tensor2D = x.reshape(newShape);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(output);
+  });
+  it("  -- more than 1 dimension set to -1 throws error", () => {
+    const newShape = [2, -1, -1];
+    // (use same input as previous test)
+    const x: tfTypes.Tensor3D = tf.range(1, 13).reshape([3, 2, 2]);
+    expect(() => x.reshape(newShape)).to.throw(
+      `Shapes can only have 1 implicit size. Found -1 at dim 1 and dim 2`
+    );
+  });
+  it("  -- a shape of [-1] flattens array", () => {
+    const newShape = [-1];
+    const output = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    // (use same input as previous test)
+    const x: tfTypes.Tensor3D = tf.range(1, 13).reshape([3, 2, 2]);
+    const y: tfTypes.Tensor1D = x.reshape(newShape);
+    expect(y).to.lookLike(output);
+  });
+}

--- a/apitests/src/tensors/transformations/setdiff1dAsync.ts
+++ b/apitests/src/tensors/transformations/setdiff1dAsync.ts
@@ -1,0 +1,50 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* See also: src/tensors/transformations/mirrorPad.ts
+  for more thorough testing of padding
+*/
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.setdiff1dAsync (x, y)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  it("  -- default", async () => {
+    const x = [1, 2, 3, 4, 5, 6];
+    const y = [1, 3, 5];
+    const expectedOut = [2, 4, 6];
+    const expectedIndices = [1, 3, 5];
+    const [out, indices]: [tfTypes.Tensor, tfTypes.Tensor] =
+      await tf.setdiff1dAsync(x, y);
+    expect(out).to.lookLike(expectedOut);
+    expect(indices).to.lookLike(expectedIndices);
+  });
+  it("  -- is not commutative", async () => {
+    const x = [1, 3, 5];
+    const y = [1, 2, 3, 4, 5, 6];
+    const expectedOut: number[] = [];
+    const expectedIndices: number[] = [];
+    const [out, indices]: [tfTypes.Tensor, tfTypes.Tensor] =
+      await tf.setdiff1dAsync(x, y);
+    expect(out).to.lookLike(expectedOut);
+    expect(indices).to.lookLike(expectedIndices);
+  });
+}

--- a/apitests/src/tensors/transformations/setdiff1dAsync.ts
+++ b/apitests/src/tensors/transformations/setdiff1dAsync.ts
@@ -2,6 +2,8 @@ import * as chai from "chai";
 const expect = chai.expect;
 import { tensorChaiPlugin } from "../../plugins/tensor-chai";
 chai.use(tensorChaiPlugin);
+import { default as chaiAsPromised } from "chai-as-promised";
+chai.use(chaiAsPromised);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
@@ -46,5 +48,17 @@ export function run() {
       await tf.setdiff1dAsync(x, y);
     expect(out).to.lookLike(expectedOut);
     expect(indices).to.lookLike(expectedIndices);
+  });
+  it("  -- error if x or y are not 1d", async () => {
+    const x = [
+      [1, 2, 3],
+      [4, 5, 6],
+    ];
+    const y = [1, 3, 5];
+    // const expectedOut = [2, 4, 6];
+    // const expectedIndices = [1, 3, 5];
+    await expect(tf.setdiff1dAsync(x, y)).to.be.rejectedWith(
+      `x should be 1D tensor, but got x (2,3).`
+    );
   });
 }

--- a/apitests/src/tensors/transformations/spaceToBatchND.ts
+++ b/apitests/src/tensors/transformations/spaceToBatchND.ts
@@ -7,10 +7,6 @@ chai.use(chaiAsPromised);
 import type tfTypes from "@tensorflow/tfjs-core";
 import * as loader from "../../load-tf";
 
-/* See also: src/tensors/transformations/mirrorPad.ts
-  for more thorough testing of padding
-*/
-
 /* MODULE TO LOAD DYNAMICALLY: */
 let tf: loader.TFModule;
 
@@ -42,6 +38,7 @@ export function run() {
     expect(y).to.haveShape(expectedShape);
     expect(y).to.lookLike(expectedResult);
   });
+
   it("  -- paddings : 1st dimension", async () => {
     // looks like paddings are added to original tensor before being mutated
     const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
@@ -60,10 +57,12 @@ export function run() {
       [[[2]], [[0]]],
     ];
     const expectedShape = [4, 2, 1, 1];
+    //assertions:
     const y = x.spaceToBatchND(blockShape, paddings);
     expect(y).to.haveShape(expectedShape);
     expect(y).to.lookLike(expectedResult);
   });
+
   it("  -- paddings : 1st dimension only left padding", async () => {
     const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const blockShape = [2, 2];
@@ -81,10 +80,12 @@ export function run() {
       [[[0]], [[4]]],
     ];
     const expectedShape = [4, 2, 1, 1];
+    // assertions:
     const y = x.spaceToBatchND(blockShape, paddings);
     expect(y).to.haveShape(expectedShape);
     expect(y).to.lookLike(expectedResult);
   });
+
   it("  -- paddings : 2nd dimension", async () => {
     const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const blockShape = [2, 2];
@@ -102,10 +103,12 @@ export function run() {
       [[[0], [4]]],
     ];
     const expectedShape = [4, 1, 2, 1];
+    // assertions:
     const y = x.spaceToBatchND(blockShape, paddings);
     expect(y).to.haveShape(expectedShape);
     expect(y).to.lookLike(expectedResult);
   });
+
   it("  -- bad padding: error", async () => {
     const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const blockShape = [2, 2];
@@ -113,6 +116,7 @@ export function run() {
       [1, 0],
       [0, 0],
     ];
+    // assertions:
     expect(() => x.spaceToBatchND(blockShape, badPaddings)).to.throw(
       `input spatial dimensions 2,2,1 with paddings 1,0,0,0 must be divisible by blockShapes 2,2`
     );

--- a/apitests/src/tensors/transformations/spaceToBatchND.ts
+++ b/apitests/src/tensors/transformations/spaceToBatchND.ts
@@ -1,0 +1,121 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import { default as chaiAsPromised } from "chai-as-promised";
+chai.use(chaiAsPromised);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* See also: src/tensors/transformations/mirrorPad.ts
+  for more thorough testing of padding
+*/
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.spaceToBatchND (x, blockShape, paddings)-- */
+export function run() {
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+
+  /* TESTS: */
+
+  it("  -- default", async () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const blockShape = [2, 2];
+    const paddings = [
+      [0, 0],
+      [0, 0],
+    ];
+    const expectedResult = [[[[1]]], [[[2]]], [[[3]]], [[[4]]]];
+    const expectedShape = [4, 1, 1, 1];
+    const y = x.spaceToBatchND(blockShape, paddings);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+  it("  -- paddings : 1st dimension", async () => {
+    // looks like paddings are added to original tensor before being mutated
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const blockShape = [2, 2];
+    const paddings = [
+      [1, 1],
+      [0, 0],
+    ];
+    const expectedResult = [
+      [[[0]], [[3]]],
+
+      [[[0]], [[4]]],
+
+      [[[1]], [[0]]],
+
+      [[[2]], [[0]]],
+    ];
+    const expectedShape = [4, 2, 1, 1];
+    const y = x.spaceToBatchND(blockShape, paddings);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+  it("  -- paddings : 1st dimension only left padding", async () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const blockShape = [2, 2];
+    const paddings = [
+      [2, 0],
+      [0, 0],
+    ];
+    const expectedResult = [
+      [[[0]], [[1]]],
+
+      [[[0]], [[2]]],
+
+      [[[0]], [[3]]],
+
+      [[[0]], [[4]]],
+    ];
+    const expectedShape = [4, 2, 1, 1];
+    const y = x.spaceToBatchND(blockShape, paddings);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+  it("  -- paddings : 2nd dimension", async () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const blockShape = [2, 2];
+    const paddings = [
+      [0, 0],
+      [2, 0],
+    ];
+    const expectedResult = [
+      [[[0], [1]]],
+
+      [[[0], [2]]],
+
+      [[[0], [3]]],
+
+      [[[0], [4]]],
+    ];
+    const expectedShape = [4, 1, 2, 1];
+    const y = x.spaceToBatchND(blockShape, paddings);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+  it("  -- bad padding: error", async () => {
+    const x: tfTypes.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const blockShape = [2, 2];
+    const badPaddings = [
+      [1, 0],
+      [0, 0],
+    ];
+    const expectedResult = [[[[1]]], [[[2]]], [[[3]]], [[[4]]]];
+    expect(() => x.spaceToBatchND(blockShape, badPaddings)).to.throw(
+      `input spatial dimensions 2,2,1 with paddings 1,0,0,0 must be divisible by blockShapes 2,2`
+    );
+  });
+}

--- a/apitests/src/tensors/transformations/spaceToBatchND.ts
+++ b/apitests/src/tensors/transformations/spaceToBatchND.ts
@@ -113,7 +113,6 @@ export function run() {
       [1, 0],
       [0, 0],
     ];
-    const expectedResult = [[[[1]]], [[[2]]], [[[3]]], [[[4]]]];
     expect(() => x.spaceToBatchND(blockShape, badPaddings)).to.throw(
       `input spatial dimensions 2,2,1 with paddings 1,0,0,0 must be divisible by blockShapes 2,2`
     );

--- a/apitests/src/tensors/transformations/squeeze.ts
+++ b/apitests/src/tensors/transformations/squeeze.ts
@@ -1,0 +1,73 @@
+import * as chai from "chai";
+const expect = chai.expect;
+import { tensorChaiPlugin } from "../../plugins/tensor-chai";
+chai.use(tensorChaiPlugin);
+import { default as chaiAsPromised } from "chai-as-promised";
+chai.use(chaiAsPromised);
+import type tfTypes from "@tensorflow/tfjs-core";
+import * as loader from "../../load-tf";
+
+/* MODULE TO LOAD DYNAMICALLY: */
+let tf: loader.TFModule;
+
+/**** ---- MOCHA TEST FUNCTION: ---- *****/
+
+/* -- tf.squeeze (x, axis?) */
+export function run() {
+  /* CONSTANTS: */
+  const INITIAL_TENSOR_VALS = [
+    [[[[1], [2], [3], [4]]], [[[5], [6], [7], [8]]]],
+  ];
+  // to inialize before each test
+  let x: tfTypes.Tensor5D;
+
+  /* HOOKS: */
+  before((done) => {
+    loader.load().then((result: loader.TFModule) => {
+      tf = result;
+      // Complete the async stuff
+      done();
+    });
+  });
+  beforeEach(() => {
+    x = tf.tensor5d(INITIAL_TENSOR_VALS);
+  });
+
+  /* TESTS: */
+
+  it("  -- default", async () => {
+    const expectedResult = [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+    ];
+    const expectedShape = [2, 4];
+    // assertions:
+    const y = x.squeeze();
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+
+  it("  -- specify dimensions", async () => {
+    const axis = [0, 4];
+    const expectedResult = [[[1, 2, 3, 4]], [[5, 6, 7, 8]]];
+    const expectedShape = [2, 1, 4];
+    // assertions:
+    const y = x.squeeze(axis);
+    expect(y).to.haveShape(expectedShape);
+    expect(y).to.lookLike(expectedResult);
+  });
+  it("  -- error : dimensions aren't of size 1", async () => {
+    const axis = [1];
+    // assertions:
+    expect(() => x.squeeze(axis)).to.throw(
+      `Can't squeeze axis 1 since its dim '2' is not 1`
+    );
+  });
+  it("  -- error : dimension out of range", async () => {
+    const axis = [5];
+    // assertions:
+    expect(() => x.squeeze(axis)).to.throw(
+      `All values in axis param must be in range [-5, 5) but got axis 5`
+    );
+  });
+}

--- a/apitests/src/utils/index.ts
+++ b/apitests/src/utils/index.ts
@@ -4,6 +4,10 @@ export {
   forEachTensorValue,
   isTrueForEach,
   isAllZeros,
+  areEqual,
+  asBoolArray,
   BasicType,
+  TFArray,
+  BoolArray,
 } from "./tensor-utils";
 export { default as TensorUtils } from "./tensor-utils";

--- a/apitests/src/utils/tensor-utils/index.ts
+++ b/apitests/src/utils/tensor-utils/index.ts
@@ -2,6 +2,24 @@ import * as tf from "@tensorflow/tfjs-core";
 
 export type BasicType = number | string | boolean;
 
+export type TFArray =
+  | number
+  | number[]
+  | number[][]
+  | number[][][]
+  | number[][][][]
+  | number[][][][][]
+  | number[][][][][][];
+
+export type BoolArray =
+  | boolean
+  | boolean[]
+  | boolean[][]
+  | boolean[][][]
+  | boolean[][][][]
+  | boolean[][][][][]
+  | boolean[][][][][][];
+
 /* --- Loops over all values in tensor */
 export function forEachTensorValue<T>(
   t: tf.Tensor,
@@ -64,6 +82,31 @@ export function areEqual(
     }
   }
   return true;
+}
+
+function _intArrToBoolArr(arr: number[]): boolean[] {
+  return arr.map((el) => (el === 0 ? false : true));
+}
+
+function _intArrToBoolArr2d(arr: number[][]): boolean[][] {
+  return arr.map((subarr) => _intArrToBoolArr(subarr));
+}
+
+function asBoolArray(t: tf.Tensor): BoolArray {
+  if (t.dtype !== "bool") {
+    throw new Error("tensor must be of type bool");
+  }
+  if (t.rank > 2) {
+    throw new Error("conversion for ranks > 2 not implemented");
+  }
+  const arr = t.arraySync();
+  if (t.rank === 1) {
+    return _intArrToBoolArr(arr as number[]);
+  } else if (t.rank === 2) {
+    return _intArrToBoolArr2d(arr as number[][]);
+  } else {
+    return [];
+  }
 }
 
 export default {

--- a/apitests/src/utils/tensor-utils/index.ts
+++ b/apitests/src/utils/tensor-utils/index.ts
@@ -92,18 +92,24 @@ function _intArrToBoolArr2d(arr: number[][]): boolean[][] {
   return arr.map((subarr) => _intArrToBoolArr(subarr));
 }
 
-function asBoolArray(t: tf.Tensor): BoolArray {
+function _intArrToBoolArr3d(arr: number[][][]): boolean[][][] {
+  return arr.map((subarr) => _intArrToBoolArr2d(subarr));
+}
+
+export function asBoolArray(t: tf.Tensor): BoolArray {
   if (t.dtype !== "bool") {
     throw new Error("tensor must be of type bool");
   }
-  if (t.rank > 2) {
-    throw new Error("conversion for ranks > 2 not implemented");
+  if (t.rank > 3) {
+    throw new Error("conversion for ranks > 3 not implemented");
   }
   const arr = t.arraySync();
   if (t.rank === 1) {
     return _intArrToBoolArr(arr as number[]);
   } else if (t.rank === 2) {
     return _intArrToBoolArr2d(arr as number[][]);
+  } else if (t.rank === 3) {
+    return _intArrToBoolArr3d(arr as number[][][]);
   } else {
     return [];
   }
@@ -116,4 +122,5 @@ export default {
   isAllZeros,
   isAllOnes,
   areEqual,
+  asBoolArray,
 };


### PR DESCRIPTION
# Tests

### Classes
- [x] [tf.Tensor](https://js.tensorflow.org/api/latest/#class:Tensor)
- [x] [tf.Variable](https://js.tensorflow.org/api/latest/#class:Variable)
- [x] [tf.TensorBuffer](https://js.tensorflow.org/api/latest/#class:TensorBuffer)

### Transformations
- [x] [tf.batchToSpaceND](https://js.tensorflow.org/api/latest/#batchToSpaceND)
- [x] [tf.broadcastArgs](https://js.tensorflow.org/api/latest/#broadcastArgs)
- [x] [tf.broadcastTo](https://js.tensorflow.org/api/latest/#broadcastTo)
- [x] [tf.cast](https://js.tensorflow.org/api/latest/#cast)
- [x] [tf.depthToSpace](https://js.tensorflow.org/api/latest/#depthToSpace)
- [x] [tf.ensureShape](https://js.tensorflow.org/api/latest/#ensureShape)
- [x] [tf.expandDims](https://js.tensorflow.org/api/latest/#expandDims)
- [x] [tf.mirrorPad](https://js.tensorflow.org/api/latest/#mirrorPad)
- [x] [tf.pad](https://js.tensorflow.org/api/latest/#pad)
- [x] [tf.reshape](https://js.tensorflow.org/api/latest/#reshape)
- [x] [tf.setdiff1dAsync](https://js.tensorflow.org/api/latest/#setdiff1dAsync)
- [x] [tf.spaceToBatchND](https://js.tensorflow.org/api/latest/#spaceToBatchND)
- [x] [tf.squeeze](https://js.tensorflow.org/api/latest/#squeeze)

## Updates to Submodules

### Tensor-Utils
- `asBoolArray(t: tf.Tensor): BoolArray`
  - given a boolean tensor, outputs an array representation
  - e.g.: `[true, false, true, true]`
  - if input isn't boolean tensor, throws an error
  - :exclamation:Implemented only up to 5th dimension
- `type TFArray`
- `type BoolArray`

##TensorChai
- `lookLike(arr: TFArray | BoolArray): void;`
  - Now calls `asBoolArray` if the given tensor is of dtype *bool*